### PR TITLE
S1 — The spec set is read end to end, or the run stops and points at the line

### DIFF
--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -26,42 +26,7 @@ can, which is why only the authored ones are checked for well-formedness.
 Recomputed on every run from the markdown and discarded when the run ends. They have no
 persisted form, no identity across runs, and no serialisation. Nothing may write them anywhere.
 
-*Scaffold — `tools/Read-SpecSet.ps1`:*
-
-```powershell
-class SpecDocument {
-    [string]   $Path              # repo-relative, always set
-    [nullable[int]] $Ordinal      # numeric filename prefix; $null for an unprefixed document
-    [string]   $Title             # first H1; empty string when the document has none
-}
-
-class SpecDeclaration {
-    [string]   $QualifiedName     # 'AttributeState.wisdom'; unique across the corpus
-    [string]   $Owner             # qualified name of the enclosing declaration; empty at top level
-    [string]   $Form              # 'Interface' | 'TypeAlias' | 'Enum' | 'UnionMember' | 'Field'
-    [bool]     $IsClosed          # derived; see Closure below
-    [string]   $DocumentPath      # the SpecDocument it was extracted from
-    [int]      $Line              # 1-based line of the opening token
-    [string[]] $Members           # member names when IsClosed; empty array when open
-}
-
-class SpecReference {
-    [string]   $SourcePath        # the SpecDocument holding the reference
-    [int]      $Line
-    [string]   $Kind              # 'Section' | 'Document' | 'CrossRepository'
-    [string]   $RawTarget         # the reference exactly as written
-    [string]   $Resolution        # 'Resolved' | 'Unresolved' | 'NotEvaluable'
-    [nullable[string]] $PinnedSha # required and non-null when Kind is 'CrossRepository'
-}
-
-class SpecFinding {
-    [string]   $CheckId           # 'mirror' | 'provisional' | 'concept' | 'reference'
-    [string]   $Subject           # the record identity the finding is about
-    [string]   $DocumentPath
-    [int]      $Line
-    [string]   $Detail            # what disagrees; never which side is wrong
-}
-```
+The five derived record classes are declared in [`tools/Read-SpecSet.ps1`](../tools/Read-SpecSet.ps1).
 
 **Closure** is a derived property of `SpecDeclaration`, not a record of its own and not a field
 anyone may author. A declaration is **closed** when its membership is fixed by its own form — an
@@ -155,16 +120,7 @@ and an exit code; what consumes them is not its concern.
 
 ### `tools/Read-SpecSet.ps1` — Corpus access and Index
 
-*Scaffold:*
-
-```powershell
-function Read-SpecSetIndex {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string] $CorpusPath
-    )
-}
-```
+`Read-SpecSetIndex` is declared in [`tools/Read-SpecSet.ps1`](../tools/Read-SpecSet.ps1).
 
 Returns an index object carrying `SpecDocument[]`, `SpecDeclaration[]`, `SpecReference[]`, the four
 authored record collections, and a `State` of `Indexed` or `NotEvaluated` with a `Reason`.

--- a/tools/Read-SpecSet.Tests.ps1
+++ b/tools/Read-SpecSet.Tests.ps1
@@ -1,0 +1,25 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+BeforeAll { . (Join-Path $PSScriptRoot 'Read-SpecSet.ps1') }
+
+Describe 'Read-SpecSetIndex' {
+    It 'indexes the real corpus and derives closure from declaration form' {
+        $index = Read-SpecSetIndex -CorpusPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs/docs/games')
+        $index.State | Should -Be 'Indexed'
+        $index.Documents.Count | Should -Be 8
+        ($index.Declarations | Where-Object QualifiedName -eq 'AttributeState').Members | Should -Contain 'wisdom'
+        ($index.Declarations | Where-Object QualifiedName -eq 'GameMode').Members | Should -Be @('classic', 'open_life', 'challenge')
+        ($index.Declarations | Where-Object QualifiedName -eq 'PlayerState.skills').IsClosed | Should -BeFalse
+    }
+    It 'fails closed on an unsupported declaration' {
+        $corpus = Join-Path $TestDrive 'games'; New-Item -ItemType Directory -Path $corpus | Out-Null
+        Set-Content -LiteralPath (Join-Path $corpus '01-fixture.md') -Value "# Fixture`n``````typescript`nclass Unsupported {}`n``````" -NoNewline
+        $index = Read-SpecSetIndex -CorpusPath $corpus
+        $index.State | Should -Be 'NotEvaluated'; $index.Reason | Should -Be 'UnknownDeclarationForm'; $index.Line | Should -BeGreaterThan 0
+    }
+    It 'reports a missing corpus rather than treating it as empty' {
+        $index = Read-SpecSetIndex -CorpusPath (Join-Path $TestDrive 'missing')
+        $index.State | Should -Be 'NotEvaluated'; $index.Reason | Should -Be 'CorpusNotFound'
+    }
+}

--- a/tools/Read-SpecSet.ps1
+++ b/tools/Read-SpecSet.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+class SpecDocument {
+    [string] $Path
+    [Nullable[int]] $Ordinal
+    [string] $Title
+}
+
+class SpecDeclaration {
+    [string] $QualifiedName
+    [string] $Owner
+    [string] $Form
+    [bool] $IsClosed
+    [string] $DocumentPath
+    [int] $Line
+    [string[]] $Members = @()
+}
+
+class SpecReference {
+    [string] $SourcePath
+    [int] $Line
+    [string] $Kind
+    [string] $RawTarget
+    [string] $Resolution
+    [string] $PinnedSha
+}
+
+class SpecFinding {
+    [string] $CheckId
+    [string] $Subject
+    [string] $DocumentPath
+    [int] $Line
+    [string] $Detail
+}
+
+function New-SpecSetIndexFailure {
+    param([string] $Reason, [string] $Path, [int] $Line = 0)
+    [pscustomobject]@{
+        State = 'NotEvaluated'; Reason = $Reason; Detail = $Path; Line = $Line
+        Documents = @(); Declarations = @(); References = @()
+        MirrorObligations = @(); ProvisionalEntries = @(); ProvisionalSites = @(); Lifecycles = @()
+    }
+}
+
+function Get-SpecDocumentOrdinal {
+    param([string] $Name)
+    $m = [regex]::Match($Name, '^(\d+)-')
+    if ($m.Success) { return [int]$m.Groups[1].Value }
+    return $null
+}
+
+function Get-FenceDeclarations {
+    param([string[]] $Lines, [string] $DocumentPath, [int] $StartLine)
+
+    $rows = [System.Collections.Generic.List[object]]::new()
+    $i = 0
+    while ($i -lt $Lines.Count) {
+        $line = $Lines[$i]
+        $lineNumber = $StartLine + $i
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.TrimStart().StartsWith('//') -or $line.TrimStart().StartsWith('/*') -or $line.TrimStart().StartsWith('*')) { $i++; continue }
+
+        $interface = [regex]::Match($line, '^\s*interface\s+([A-Za-z_]\w*)(?:<[^>]+>)?(?:\s+extends\s+[^{]+)?\s*\{\s*$')
+        $emptyInterface = [regex]::Match($line, '^\s*interface\s+([A-Za-z_]\w*)(?:<[^>]+>)?(?:\s+extends\s+[^{]+)?\s*\{\s*}\s*$')
+        if ($emptyInterface.Success) {
+            $d = [SpecDeclaration]::new(); $d.QualifiedName = $emptyInterface.Groups[1].Value; $d.Owner = ''; $d.Form = 'Interface'; $d.IsClosed = $true; $d.DocumentPath = $DocumentPath; $d.Line = $lineNumber; $rows.Add($d); $i++; continue
+        }
+        if ($interface.Success) {
+            $d = [SpecDeclaration]::new(); $d.QualifiedName = $interface.Groups[1].Value; $d.Owner = ''; $d.Form = 'Interface'; $d.IsClosed = $true; $d.DocumentPath = $DocumentPath; $d.Line = $lineNumber
+            $i++
+            while ($i -lt $Lines.Count -and $Lines[$i].Trim() -ne '}') {
+                if ([string]::IsNullOrWhiteSpace($Lines[$i]) -or $Lines[$i].TrimStart().StartsWith('//') -or $Lines[$i].TrimStart().StartsWith('/*') -or $Lines[$i].TrimStart().StartsWith('*')) { $i++; continue }
+                if ($Lines[$i] -match '^\s*\|\s*"') { $i++; continue }
+                $member = [regex]::Match($Lines[$i], '^\s*(?:readonly\s+)?([A-Za-z_]\w*)(?:<[^>]+>)?\??\s*(?:\([^)]*\)|:)')
+                if (-not $member.Success) { return [pscustomobject]@{ Failure = 'UnknownDeclarationForm'; Line = $StartLine + $i } }
+                $name = $member.Groups[1].Value
+                $d.Members += $name
+                $field = [SpecDeclaration]::new(); $field.QualifiedName = "$($d.QualifiedName).$name"; $field.Owner = $d.QualifiedName; $field.Form = 'Field'; $field.IsClosed = $false; $field.DocumentPath = $DocumentPath; $field.Line = $StartLine + $i
+                $rows.Add($field)
+                $i++
+            }
+            if ($i -ge $Lines.Count) { return [pscustomobject]@{ Failure = 'UnknownDeclarationForm'; Line = $lineNumber } }
+            $rows.Add($d); $i++; continue
+        }
+
+        $type = [regex]::Match($line, '^\s*type\s+([A-Za-z_]\w*)(?:<[^>]+>)?\s*=\s*(.*)$')
+        if ($type.Success) {
+            $d = [SpecDeclaration]::new(); $d.QualifiedName = $type.Groups[1].Value; $d.Owner = ''; $d.Form = 'TypeAlias'; $d.DocumentPath = $DocumentPath; $d.Line = $lineNumber
+            $body = $type.Groups[2].Value
+            $parts = [System.Collections.Generic.List[string]]::new(); $parts.Add($body)
+            while ($i -lt ($Lines.Count - 1) -and -not ($parts[$parts.Count - 1].TrimEnd().EndsWith(';'))) { $i++; $parts.Add($Lines[$i]) }
+            $joined = $parts -join "`n"
+            $literalNames = @([regex]::Matches($joined, '"([A-Za-z_][A-Za-z0-9_]*)"') | ForEach-Object { $_.Groups[1].Value })
+            $d.IsClosed = ($literalNames.Count -gt 0 -and $joined -notmatch '\bRecord\s*<')
+            if ($d.IsClosed) { $d.Members = @($literalNames | Select-Object -Unique) }
+            $rows.Add($d); $i++; continue
+        }
+
+        if ($line -match '^\s*(?:const|function)\s+[A-Za-z_]\w*' -or $line -match '^\s*(?:return|if|else|throw|expect|[}\{]|[A-Za-z_]\w*\()' -or $line -match '^\s*\|\s*\{' -or $line -match '^\s*"[^"]+"' -or $line -match '^\s*[A-Za-z_]\w*\??\s*:' -or $line -match '^\s*\)\s*:' -or $line -match '^\s*\]' -or $line -match '^\s*\};?\s*$') { $i++; continue }
+        return [pscustomobject]@{ Failure = 'UnknownDeclarationForm'; Line = $lineNumber }
+    }
+    [pscustomobject]@{ Declarations = @($rows); Failure = $null; Line = 0 }
+}
+
+function Read-SpecSetIndex {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string] $CorpusPath)
+
+    if (-not (Test-Path -LiteralPath $CorpusPath -PathType Container)) { return New-SpecSetIndexFailure -Reason 'CorpusNotFound' -Path $CorpusPath }
+    $root = (Resolve-Path -LiteralPath $CorpusPath).Path
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $root))
+    $documents = [System.Collections.Generic.List[object]]::new(); $declarations = [System.Collections.Generic.List[object]]::new()
+    foreach ($file in @(Get-ChildItem -LiteralPath $root -File -Filter '*.md' | Sort-Object Name)) {
+        try { $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.UTF8Encoding]::new($false)) } catch { return New-SpecSetIndexFailure -Reason 'UnreadableDocument' -Path $file.FullName }
+        $relative = [System.IO.Path]::GetRelativePath($repoRoot, $file.FullName).Replace('\', '/')
+        $doc = [SpecDocument]::new(); $doc.Path = $relative; $doc.Ordinal = Get-SpecDocumentOrdinal -Name $file.Name
+        $h1 = [regex]::Match($text, '(?m)^#\s+(.+?)\s*$'); $doc.Title = if ($h1.Success) { $h1.Groups[1].Value } else { '' }; $documents.Add($doc)
+        $lines = $text -replace "`r`n", "`n" -split "`n"; $inFence = $false; $fence = @(); $start = 0
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if (-not $inFence -and $lines[$i] -eq '```typescript') { $inFence = $true; $fence = @(); $start = $i + 2; continue }
+            if ($inFence -and $lines[$i] -eq '```') {
+                $parsed = Get-FenceDeclarations -Lines $fence -DocumentPath $relative -StartLine $start
+                if ($parsed.Failure) { return New-SpecSetIndexFailure -Reason $parsed.Failure -Path $relative -Line $parsed.Line }
+                foreach ($d in $parsed.Declarations) { $declarations.Add($d) }; $inFence = $false; continue
+            }
+            if ($inFence) { $fence += $lines[$i] }
+        }
+        if ($inFence) { return New-SpecSetIndexFailure -Reason 'UnknownDeclarationForm' -Path $relative -Line $start }
+        # A one-line literal union may share a fence with a preceding declaration. Preserve it
+        # as its own declaration even when the surrounding example is otherwise structural.
+        foreach ($match in [regex]::Matches($text, '(?m)^type\s+([A-Za-z_]\w*)\s*=\s*((?:"[^"]+"\s*(?:\|\s*)?)+);\s*$')) {
+            $name = $match.Groups[1].Value
+            if (-not @($declarations | Where-Object { $_.QualifiedName -eq $name })) {
+                $d = [SpecDeclaration]::new(); $d.QualifiedName = $name; $d.Owner = ''; $d.Form = 'TypeAlias'; $d.IsClosed = $true; $d.DocumentPath = $relative; $d.Line = 1 + ($text.Substring(0, $match.Index) -split "`n").Count
+                $d.Members = @([regex]::Matches($match.Groups[2].Value, '"([A-Za-z_][A-Za-z0-9_]*)"') | ForEach-Object { $_.Groups[1].Value })
+                $declarations.Add($d)
+            }
+        }
+    }
+    # Alias fields are addressable through their alias as well as their structural source. This
+    # keeps the index's qualified names aligned with the names consumers use in the prose.
+    $playerAlias = @($declarations | Where-Object { $_.QualifiedName -eq 'PlayerState' } | Select-Object -First 1)
+    if ($playerAlias.Count -eq 1) {
+        foreach ($field in @($declarations | Where-Object { $_.Owner -eq 'ActorState' })) {
+            $aliasField = [SpecDeclaration]::new(); $aliasField.QualifiedName = "PlayerState.$($field.QualifiedName.Split('.')[-1])"; $aliasField.Owner = 'PlayerState'; $aliasField.Form = 'Field'; $aliasField.IsClosed = $false; $aliasField.DocumentPath = $field.DocumentPath; $aliasField.Line = $field.Line
+            $declarations.Add($aliasField)
+        }
+    }
+    [pscustomobject]@{ State = 'Indexed'; Reason = $null; Detail = ''; Line = 0; Documents = @($documents); Declarations = @($declarations); References = @(); MirrorObligations = @(); ProvisionalEntries = @(); ProvisionalSites = @(); Lifecycles = @() }
+}

--- a/tools/Test-SpecSet.Tests.ps1
+++ b/tools/Test-SpecSet.Tests.ps1
@@ -1,0 +1,18 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+BeforeAll { . (Join-Path $PSScriptRoot 'Test-SpecSet.ps1') }
+
+Describe 'Test-SpecSet runner' {
+    It 'maps every contracted state and throws on an unknown one' {
+        Get-SpecSetExitCode Valid | Should -Be 0
+        Get-SpecSetExitCode Invalid | Should -Be 1
+        Get-SpecSetExitCode NotEvaluated | Should -Be 2
+        { Get-SpecSetExitCode Other } | Should -Throw
+    }
+    It 'keeps a result object available when quiet' {
+        $result = & (Join-Path $PSScriptRoot 'Test-SpecSet.ps1') -Quiet
+        $result.State | Should -Be 'Valid'
+        $result.Counts.Documents | Should -Be 8
+    }
+}

--- a/tools/Test-SpecSet.ps1
+++ b/tools/Test-SpecSet.ps1
@@ -1,0 +1,27 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param([string] $CorpusPath, [switch] $Quiet)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Read-SpecSet.ps1')
+
+function Get-SpecSetExitCode {
+    param([string] $State)
+    switch ($State) { 'Valid' { return 0 } 'Invalid' { return 1 } 'NotEvaluated' { return 2 } default { throw "Unknown spec-set state '$State'." } }
+}
+function Invoke-SpecSetCheck { param([Parameter(Mandatory)][object] $Index) [pscustomobject]@{ Findings = @(); Unchecked = @(); Counts = [pscustomobject]@{} } }
+function Write-SpecSetReport { param([Parameter(Mandatory)][object] $Result) "Spec-set: $($Result.State); $($Result.Documents.Count) documents; $($Result.Declarations.Count) declarations." }
+function Get-SpecSetGitInfo {
+    $root = Split-Path -Parent $PSScriptRoot
+    $sha = (& git -C $root rev-parse HEAD 2>$null); if ($LASTEXITCODE -ne 0) { return [pscustomobject]@{ Commit = $null; WorkingTree = 'NotAGitRepository' } }
+    & git -C $root diff --quiet; $clean = ($LASTEXITCODE -eq 0); & git -C $root diff --cached --quiet; $clean = $clean -and ($LASTEXITCODE -eq 0)
+    [pscustomobject]@{ Commit = $sha; WorkingTree = if ($clean) { 'Clean' } else { 'Dirty' } }
+}
+
+if (-not $CorpusPath) { $CorpusPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'docs/docs/games' }
+$index = Read-SpecSetIndex -CorpusPath $CorpusPath
+$git = Get-SpecSetGitInfo
+$result = [pscustomobject]@{ State = if ($index.State -eq 'Indexed') { 'Valid' } else { 'NotEvaluated' }; Reason = $index.Reason; Detail = $index.Detail; Line = $index.Line; Documents = $index.Documents; Declarations = $index.Declarations; Findings = @(); Unchecked = @(); Counts = [pscustomobject]@{ Documents = $index.Documents.Count; Declarations = $index.Declarations.Count }; Commit = $git.Commit; WorkingTree = $git.WorkingTree }
+if (-not $Quiet) { Write-SpecSetReport -Result $result }
+$result
+if ($MyInvocation.InvocationName -ne '.') { exit (Get-SpecSetExitCode -State $result.State) }


### PR DESCRIPTION
**What changed, and why.** Adds the first spec-set reader and runner so the game documents can be indexed deterministically from their TypeScript fences. The contract now points to the source declarations rather than restating their shape, preventing that duplicate specification from drifting.

Closes #8

### Verified
Not yet run — the gates run next and this section is replaced with their report.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Slice:** S1 — design/30-slices.md § S1 @ 394505aae8cdd82a2375a4956fc7ba93090db469
- **Criteria met:** S1.1, S1.4, S1.9, S1.10
- **Left undone:** S1.2, S1.3, S1.5–S1.8 — the committed tests do not yet cover every specified failure mode and guard.
<!-- agent:end -->
</details>