### PR TITLE
S2 — Every push runs the checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,54 @@
+name: Verify
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+
+      # verification: true
+      - name: Parse-check PowerShell scripts
+        shell: pwsh
+        run: |
+          $parseErrors = Get-ChildItem -Path . -Recurse -Filter '*.ps1' | ForEach-Object {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref] $tokens, [ref] $errors) | Out-Null
+            $errors
+          }
+          if ($parseErrors) {
+            $parseErrors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
+      # verification: true
+      - name: Run Pester tests
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: Invoke-Pester -Path tools -Output Detailed
+
+      # verification: true
+      - name: Validate the core/companion split
+        shell: pwsh
+        run: ./tools/Test-Companion.ps1
+
+      # verification: true
+      - name: Check the design state against the tree
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./tools/Test-DesignState.ps1
+
+      # verification: true
+      - name: Check the spec set
+        shell: pwsh
+        run: ./tools/Test-SpecSet.ps1


### PR DESCRIPTION
**What changed, and why.** Adds the repository verification workflow so each push and pull request runs the existing checker and tool gates. The five verdict-producing steps are explicitly marked for `/verify`, while checkout and Pester installation remain unflagged runner preparation.

### Verified
S2-specific checks passed locally; the full suite remains blocked by an unrelated existing design-state closure failure, detailed below.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Slice:** S2 — `design/30-slices.md` § S2 @ `394505aae8cdd82a2375a4956fc7ba93090db469`
- **Criteria met:** S2.1, S2.2, S2.3, S2.4
- **Left undone:** S2.5 — `Invoke-Pester -Path tools` has one pre-existing failure in `Read-DesignState.Tests.ps1`, which expects absent `design/state/work/` closures.
<!-- agent:end -->
</details>