### PR TITLE
Make spec-set validation fail closed when the provisional register is absent

### DIFF
--- a/.claude/gates.json
+++ b/.claude/gates.json
@@ -1,0 +1,26 @@
+{
+  "manifestHash": "098c1974239fc9417c3048c57d060d0e50c6e52524393e355d247125bac5f93a",
+  "generated": "2026-08-21",
+  "gates": [
+    {
+      "command": "Parse every *.ps1 with System.Management.Automation.Language.Parser.ParseFile",
+      "name": "Parse-check PowerShell scripts"
+    },
+    {
+      "command": "Invoke-Pester -Path tools -Output Detailed -PassThru",
+      "name": "Run Pester tests"
+    },
+    {
+      "command": "./tools/Test-Companion.ps1",
+      "name": "Validate the core/companion split"
+    },
+    {
+      "command": "./tools/Test-DesignState.ps1",
+      "name": "Check the design state against the tree"
+    },
+    {
+      "command": "./tools/Test-SpecSet.ps1",
+      "name": "Check the spec set"
+    }
+  ]
+}

--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -1,0 +1,27 @@
+{
+  "gates": [
+    {
+      "name": "Parse-check PowerShell scripts",
+      "status": "Passed"
+    },
+    {
+      "name": "Run Pester tests",
+      "status": "Failed",
+      "detail": "Tests completed in 74.17s. Tests Passed: 249, Failed: 9, Skipped: 0, Inconclusive: 0, NotRun: 0. Failed: Read-DesignState.Tests.ps1 S4.6 and GlobDisagreement; Test-DesignState.Tests.ps1 S12.5, S7.9, S16.1/S16.2, S16.5, S17.2, S18.6; Update-DesignProjection.Tests.ps1 S7.2."
+    },
+    {
+      "name": "Validate the core/companion split",
+      "status": "Passed"
+    },
+    {
+      "name": "Check the design state against the tree",
+      "status": "DidNotRun",
+      "reason": "Exit code 2: ContractListUnreadable (SectionNotFound and GlobTableNotFound), ProjectorFailed (exited 1), and TrackerUnavailable for issues #8 through #14."
+    },
+    {
+      "name": "Check the spec set",
+      "status": "DidNotRun",
+      "reason": "Exit code 2: RegisterAbsent — No provisional-register region exists, so provisional-number checks could not run."
+    }
+  ]
+}

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -142,19 +142,8 @@ carried instead.
 
 ### `tools/Test-SpecSet.ps1` — Checks, Report, Runner
 
-*Scaffold:*
-
-```powershell
-[CmdletBinding()]
-param(
-    [string] $CorpusPath,
-    [switch] $Quiet
-)
-
-function Invoke-SpecSetCheck   { param([Parameter(Mandatory)][object] $Index) }
-function Get-SpecSetExitCode   { param([string] $State) }
-function Write-SpecSetReport   { param([Parameter(Mandatory)][object] $Result) }
-```
+The runner and its check/report functions are declared in
+[`tools/Test-SpecSet.ps1`](../tools/Test-SpecSet.ps1).
 
 The entry point emits a result object and then exits, guarded by
 `if ($MyInvocation.InvocationName -ne '.')` so the Pester file can dot-source it — the structure

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -1,23 +1,63 @@
-# Contract — Life in the Fast Lane (spec set)
+# Contract — Life in the Fast Lane repository
 
-Derived from [`10-design.md`](10-design.md). Binding on every slice.
+The spec-set path is derived from [`10-design.md`](10-design.md). The installed design-state path
+is restored from the AgentKit commit pinned in [`.claude/kit.json`](../.claude/kit.json). Binding
+on every slice.
 
-The system contracted here is the **spec-set checker** and the **marker vocabulary** the corpus
-carries for it. The corpus's own meaning — the game, the engine, the numbers — is not this
-document's subject and is never constrained by it.
+The systems contracted here are the **spec-set checker**, the **marker vocabulary** the corpus
+carries for it, and the installed **design-state mechanism**. The corpus's own meaning — the game,
+the engine, the numbers — is not this document's subject and is never constrained by it.
 
-Invariant ids in this document are prefixed `SS`. They are a separate namespace from the `I<n>`
-ids that `AGENTS.md` and `.claude/commands/*.md` cite, which belong to the agent kit's own
-contract and are not referenced here.
+Spec-set invariant ids are prefixed `SS`. They are a separate namespace from the `I<n>` ids that
+`AGENTS.md` and `.claude/commands/*.md` cite, which belong to the agent kit contract restored here.
 
 **Scaffold notice.** Declarations below marked *scaffold* exist here only until the slice that
 materialises them lands. That slice replaces the block with a pointer to the declaring file in the
 same commit, and what remains is the surrounding semantics. Nothing in this document may be read
 as authorising a second copy of a declaration the tree carries.
 
+## Contract scopes
+
+This repository has two standing contract paths:
+
+- The spec-set checker derived from design/10-design.md in this repository.
+- The installed AgentKit design-state mechanism shipped by the commit pinned in
+  .claude/kit.json. The pin is provenance only: all installed checks remain offline and
+  resolve their contract from this file and the local tree.
+
+A later contract run for either path preserves the other. Neither path may rewrite the file
+from a blank document. Names prefixed SS belong to the spec-set path; names prefixed I and
+the divergence classes belong to the installed design-state path.
+
 ## Types
 
-Nine record types. Five derived, four authored. The split is the load-bearing distinction and is
+### Installed design-state records
+
+The record grammar, field tables, factories, and result shapes are declared in
+tools/Read-DesignState.ps1 and tools/Test-DesignState.ps1. This contract carries the semantics
+their declarations cannot express:
+
+- Derived edges are never authored. Consumers, BoundBy, Decision.Affects, and
+  Question.Affects exist only as projections. Contract.Owner is the only authored reverse
+  edge, and OwnerMismatch checks it.
+- Omitted and empty lists are different facts. Every list-valued field is present, empty when
+  it has no members; an absent scalar has no value.
+- Retired records keep their ids resolvable, leave every orientation closure, and stop having
+  their anchors checked. No other meaning changes.
+- Archival is excluded from the orientation closure. A closure is exactly one hop and is
+  measured from whole record files.
+- A code-enforced invariant requires Evidence. A superseded decision requires SupersededBy.
+  An answered question requires AnsweredBy.
+- WorkRef is a mirror, never authority. MirroredAt and Rank are always present.
+- Reader failures reproduce the offending line verbatim and never discard records that did
+  parse.
+
+Marked-region identity and form consistency are defined under Authored records below and apply
+to both contract paths.
+
+### Spec-set records
+
+Eight record types. Four derived, four authored. The split is the load-bearing distinction and is
 not an implementation detail: a derived record cannot drift from the corpus, and an authored one
 can, which is why only the authored ones are checked for well-formedness.
 
@@ -26,7 +66,7 @@ can, which is why only the authored ones are checked for well-formedness.
 Recomputed on every run from the markdown and discarded when the run ends. They have no
 persisted form, no identity across runs, and no serialisation. Nothing may write them anywhere.
 
-The five derived record classes are declared in [`tools/Read-SpecSet.ps1`](../tools/Read-SpecSet.ps1).
+The four derived record classes are declared in [`tools/Read-SpecSet.ps1`](../tools/Read-SpecSet.ps1).
 
 **Closure** is a derived property of `SpecDeclaration`, not a record of its own and not a field
 anyone may author. A declaration is **closed** when its membership is fixed by its own form — an
@@ -53,8 +93,10 @@ never generated, checked for presence and well-formedness like any other region.
 syntax is introduced and no sidecar file is created.** The vocabulary below is the whole addition.
 
 Each region uses the declared form `<!-- <id>:declared:start -->` … `<!-- <id>:declared:end -->`.
-Ids are unique across the corpus — one namespace, shared with any projected region that may later
-exist, per the collision rule `AGENTS.md` already states.
+A region's identity is `(document, id)`, so one id may be reused in different documents. The id
+still has one form repository-wide: if any document uses an id as projected, no document may use
+that id as declared, and vice versa. This is the collision rule `AGENTS.md` already states. Within
+one document, an id occurs at most once.
 
 | Record | Region id | Lives in | Body |
 |---|---|---|---|
@@ -80,6 +122,30 @@ the index; the broad reading is not enumerable mechanically at all, and a check 
 what is missing does not check completeness.
 
 ## Persisted schemas
+
+### Installed design-state schema
+
+design/state/ is persisted local contract state, one UTF-8 LF Markdown file per record:
+
+| Id | File |
+|---|---|
+| unit/<kind>/<slug> | design/state/units/<kind>/<slug>.md |
+| I<n> | design/state/invariants/I<n>.md |
+| contract/<slug> | design/state/contracts/<slug>.md |
+| decision/<date>-<slug> | design/state/decisions/<date>-<slug>.md |
+| question/<slug> | design/state/questions/<slug>.md |
+| work/<issue> | design/state/work/<issue>.md |
+
+The file path is the primary key and the Id line must agree with it. Enumeration is a directory
+walk: there is no manifest, cache, lock, lease, or coordination file. Git is the arbitration
+mechanism.
+
+Migration preserves the existing WorkRef records byte-for-byte and adds records only for
+artifacts and decisions that already exist. It must not create an artifact merely to give a
+record an anchor, must not alter any existing decision-log entry, and must not infer a resolved
+question. Missing information is reported, not invented.
+
+### Spec-set checker persistence
 
 **The checker persists nothing.** No database, no cache, no sidecar, no report file, no state
 directory. Every derived record is recomputed per run and discarded. A run that fails leaves the
@@ -117,6 +183,77 @@ migrate it by inventing one.**
 and an exit code; what consumes them is not its concern.
 
 ## Public surface
+
+### Installed AgentKit surfaces
+
+The parameter lists and result fields are declared in the named files and are not repeated here.
+The following semantics are binding:
+
+#### tools/Wait-PullRequestCheck.ps1
+
+HeadSha remains mandatory and has no default. The script always emits its WaitResult, including
+on failure; exit codes are 0 Passed, 1 Failed, 2 NotEvaluated. It never prompts, reruns a check,
+merges, resolves, or writes.
+
+#### tools/Test-DesignDrift.ps1
+
+Read-only against both sides. Exit 0 means no drift, 1 means drift, and 2 means the comparison
+could not be completed. An unparseable criterion id is reported and never dropped.
+
+#### tools/Test-Companion.ps1
+
+The category vocabulary comes from .claude/COMPANIONS.md. Missing, empty, and frontmatter-only
+companions are absent rather than overrides. Exit codes are 0 Valid, 1 Invalid, 2 NotEvaluated.
+
+#### tools/Read-DesignState.ps1
+
+Emits a graph and never throws for malformed state. Every unrecognised line is reported verbatim.
+It writes nothing. An absent state set is an empty graph; the checker decides what absence means.
+
+#### tools/Test-DesignState.ps1
+
+Always emits Findings, Reported, and CouldNotEvaluate. Exit 2 takes precedence over exit 1.
+Closure size is the sum of whole record files. It names the largest closure on every completed
+run, regenerates before comparing projections, normalises line endings only, and writes nothing.
+
+#### tools/Update-DesignProjection.ps1
+
+DryRun writes nothing. A normal run writes only inside an existing projected region, never
+creates a region, never writes inside a declared region, never reads a rendered region as input,
+and is idempotent and order-independent.
+
+#### tools/Update-WorkMirror.ps1
+
+Only /track invokes it. It writes WorkRef records only, stamps MirroredAt on every write, and
+always supplies Rank using project order, then milestone, then issue number. An unreachable
+tracker is NotEvaluated and never an empty mirror.
+
+#### .claude/commands/fix.md
+
+Implements against one bug issue agent block, reproduces first, never edits design/, never opens
+an issue for an unreproduced defect, and never absorbs a contract or public-interface change.
+
+#### .claude/commands/resolve.md
+
+Classifies the full thread table before acting. It delegates head-specific check observation to
+Wait-PullRequestCheck.ps1 and resolves only a satisfied Defect-class thread under AGENTS.md.
+
+### Artifacts of a unit kind
+
+This table is the canonical policy input for GlobDisagreement. Both pattern cells contain tokens
+only. Parsed patterns are expanded only for comparison; they never drive artifact enumeration.
+
+| Kind | Glob | Excluded |
+|---|---|---|
+| command | `.claude/commands/*.md` | `*-local.md` |
+| script | `tools/*.ps1` | `*.Tests.ps1` |
+| document | `design/*.md`, `templates/design/*.md`, `*.md`, `.claude/COMPANIONS.md`, `.github/ISSUE_TEMPLATE/*.md`, `codex/PROFILES.md` | `design/FROZEN.md`, `CLAUDE.md` |
+| invariant | not a tree path | — |
+
+The invariant kind is the I<n> rows in Invariants below. The other three kinds are resolved from
+the table and independently enumerated by the checker; any difference is GlobDisagreement.
+
+### Spec-set checker surfaces
 
 ### `tools/Read-SpecSet.ps1` — Corpus access and Index
 
@@ -171,7 +308,8 @@ Authors write these; no code declares them, so this is their only home. The four
 *Authored records* above. Binding on the corpus:
 
 - A region's opening and closing markers must match and must not nest.
-- An id must be unique corpus-wide.
+- A `(document, id)` pair must be unique, and one id must not appear in both marker forms anywhere
+  in the repository.
 - A region must have a non-empty body.
 - `provisional-register` occurs exactly once across the whole corpus.
 
@@ -192,6 +330,133 @@ renaming one renames a gate in every report that mentions it.
 
 ## Error semantics
 
+### Wait-PullRequestCheck.ps1
+
+| WaitFailure | Raised when | Retryable | Caller does |
+|---|---|---|---|
+| HeadMoved | HeadSha is not the pull request current head | Yes, with the new SHA | Re-read the head; never retry the old SHA |
+| TimedOut | A check remains non-terminal at the deadline | Yes | Report the named checks as did-not-run; do not resolve |
+| UnknownBucket | The provider returns an unknown bucket | No | Stop and report the bucket verbatim |
+| NoChecksConfigured | The pull request reports zero checks | No | Report that nothing was evaluated |
+| GhUnavailable | gh is absent or unauthenticated | No | Report a gate that did not run |
+| PullRequestMissing | No such pull request exists | No | Stop |
+
+State Failed is not an error: the script successfully determined that a check failed. Every
+failure returns a structured WaitResult rather than throwing a bare string.
+
+### The divergence classes
+
+**This is the closed list.** `Test-DesignState.ps1` declares the same ids and one blocking class
+compares the two; the script is the detection and this document is the policy. A class not on
+this list does not exist, and adding one is a contract amendment.
+
+**Blocking.** Every one is evaluable from the checkout alone — no network, no tracker, no
+running service (I22). That rule is what decides membership; it is not a coincidence of the
+list.
+
+| Class | Raised when | Caller sees |
+|---|---|---|
+| `UnresolvedId` | A record names an id with no record | The referring record and the missing id |
+| `AnchorMissing` | An **active** record carries a tree-pointer field naming a path not in the tree — a unit's `Anchor`, a contract's `Declaration`, or any entry of an `Evidence` list | The record, the field, and the path. **Which of the two sides is wrong is the user's call** |
+| `OwnerMismatch` | A contract's `Owner` is not the unique active unit whose `Exposes` names that contract — nobody exposes it, or two units do | The contract, its `Owner`, and every unit exposing it |
+| `UnrecordedArtifact` | A tree artifact of a unit kind has no record | The unrecorded artifact |
+| `ProjectionStale` | A region differs from its regeneration, after line-ending normalisation | A diff of the region |
+| `RegionMalformed` | A marked region of either kind is unbalanced or nested | The document and the marker |
+| `IdCollision` | An id is duplicated, renumbered, disagrees with its file path, or appears in both the projected and the declared marker form | Every file claiming it |
+| `DecisionAnchorAmbiguous` | A decision anchor resolves to zero or two log headings | The anchor and the count |
+| `LogEntryUnrecorded` | A log heading has no decision record | The entry's heading |
+| `EnforcementUnevidenced` | A conditionally-required field is absent on a record whose own `Status` or `Enforcement` requires it — an invariant with `Enforcement: code` and no `Evidence`, a decision with `Status: superseded` and no `SupersededBy`, or a question with `Status: answered` and no `AnsweredBy` | The record, the absent field, and the value that required it |
+| `ClosureOverBudget` | A closure exceeds 16,384 bytes | The unit, its size, and its largest contributor |
+| `ClassListDisagreement` | The checker's declared class ids differ from this document's list | Both sets, and the difference in each direction |
+| `GlobDisagreement` | For a globbed unit kind, the file set § *Artifacts of a unit kind*'s patterns resolve to differs from the set the checker's enumeration returns | The kind, the direction, and the paths |
+
+**`GlobDisagreement` compares file sets, not tokens, and only in that direction.** Comparing the
+patterns as text would be a third id-level check in a document that already knows id-level checks
+miss definition drift — the very complaint two paragraphs below. Resolving both sides against the
+checkout instead means the table is checked for what it *means*, and it is what qualifies the
+class as blocking under I22 on the rule's own terms: expansion needs the checkout and nothing
+else. The `invariant` kind is outside the comparison because it has no pattern in either cell,
+which is a fact about the table rather than an exemption the checker carries.
+
+**What a set comparison cannot see, stated rather than left to be found: an exclusion that
+excludes nothing in this checkout.** `*-local.md` is the standing example — the cell's own reason
+is that this repository ships no companion — so removing it from the table changes no resolved
+set here and the class stays silent. That is the comparison working as specified, not a hole in
+it, and the exposure is bounded by the same fact that causes it: a divergence invisible here is
+invisible because it has no artifact here to be wrong about. It becomes visible in the first
+checkout that has one.
+
+**`AnchorMissing` is named for a unit's `Anchor` and checks every tree pointer a record
+carries.** `Contract.Declaration` and the `Evidence` list on a unit or an invariant record are
+restatements of a tree path exactly as `Anchor` is, so leaving them unresolved is the unchecked
+restatement I15 forbids — and it was already live, because unit records carry `Evidence` today.
+One class covers all three because the check, the remedy, and the reason each is evaluable from
+the checkout alone (I22) are the same in every case; a second class would have split one rule
+across two ids and widened the closed list for nothing. **The name reading narrower than what
+it checks is the price, and it is paid deliberately** — renaming it costs the closed list, the
+checker's declared ids, and the tests that cite it by name.
+
+Three exemptions, each of which would otherwise block forever:
+
+- **A retired record is exempt entirely** (I30). Its artifact is gone by definition, which is
+  why it was retired.
+- **An invariant record's `Anchor` is the invariant number, not a path.** Its resolution check
+  is well-formedness and uniqueness, and it is `IdCollision`'s, never `Test-Path`'s.
+- **A contract's `Declaration` of the literal `prose` resolves to nothing on purpose.** A
+  Markdown command surface has no declaration to point at, and that is the field's documented
+  second value rather than an absent path.
+
+**`EnforcementUnevidenced` is named for the invariant case and covers all three conditional
+requirements**, on the reasoning that widened `AnchorMissing` rather than splitting it. A scalar
+is omitted when it has no value, so a conditional scalar's absence is indistinguishable from a
+field nobody filled in; the check, the remedy, and the reason each is evaluable from the checkout
+alone (I22) are identical in all three cases, and a second class would have split one rule across
+two ids for nothing. **The name reading narrower than what it checks is the price, paid
+deliberately and for the second time in this list.**
+
+**A widened class definition is invisible to `ClassListDisagreement`, and that gap outlives the
+widening that exposed it.** That class compares class *ids*, and an id does not change when what
+it detects does, so a contract widened ahead of its detection stays green until the slice lands —
+as this one did at S18, which is why the three cases above read as one rule rather than as one
+rule and two intentions. **`GlobDisagreement` is the counter-example that fixes the shape of the
+remedy rather than an exception to it**: the glob table used to be named here as the same silent
+divergence, and what closed it was resolving both sides against the checkout instead of comparing
+their names. A definition has no checkout to resolve against, so that remedy does not carry, and
+nothing on the closed list closes this one.
+
+**Reported, never blocking.** Each fails in exactly the environment where the failure means
+nothing, which is why none of them is on the list above.
+
+| Class | Raised when | Why it never blocks |
+|---|---|---|
+| `MirrorStale` | A `WorkRef`'s `MirroredAt` is not the current commit | The mirror is stale by construction; that is its documented state, not a divergence |
+| `WorkStateDivergence` | A `WorkRef` disagrees with the tracker | Needs `gh`. A build that fails on an unauthenticated CLI reports an absent comparison as a divergence |
+| `PinAncestry` | A cited commit is not an ancestor of the default branch | A shallow CI checkout has no history to answer with, and "could not check" must not read as "checked and failed" |
+| `SemanticDisagreement` | A model judges a record's claim untrue | Permanently reported. The brief's *no formal specification of behaviour* non-goal puts it out of reach, and a build that fails on a model's opinion is a build nobody trusts |
+
+**Could not evaluate.** Exit 2, and **never** a pass (I19, I20).
+
+| `DesignStateFailure` | Raised when | Caller does |
+|---|---|---|
+| `StateSetAbsent` | `design/state/` missing, or present with zero records | Report that nothing was checked. The expected state in every installed target |
+| `RecordUnparseable` | A line matches no production | Report the file, the line number, and the line **verbatim**. Never drop it |
+| `TrackerUnavailable` | `gh` missing or unauthenticated | Report the tracker classes as not compared; the rest of the run completes |
+| `ShallowCheckout` | No history for `merge-base` | Report that ancestry was not checked, and why. Never a pass |
+| `ProjectorFailed` | `Update-DesignProjection.ps1 -DryRun` non-zero or absent | Report `ProjectionStale` as uncomputed, not as clean |
+| `ContractListUnreadable` | A list this document is canonical for cannot be read or parsed — the divergence classes, § *Artifacts of a unit kind*, or § *Invariants* | Report the class it feeds as uncomputed: `ClassListDisagreement`, `GlobDisagreement`, or `UnrecordedArtifact`'s invariant half. **Read-and-disagrees is a finding; cannot-read is not** |
+
+### The freeze
+
+While `design/FROZEN.md` exists: every blocking class is **downgraded to reported**, the count
+downgraded is stated, and the marker's `Frozen because` and `Lifts when` are reproduced
+**verbatim**. Exit 2 still stands (I21).
+
+A freeze permits known staleness. It does not permit a checker that could not run, and treating
+those the same would make writing one file a way to switch the gate off — including for a
+broken checker, which has nothing to do with the staleness a freeze is meant to permit.
+
+### Spec-set checker errors
+
 Non-retryable, all of them, everywhere. Every path is a local, deterministic, read-only pass over
 files on disk. There is nothing to retry, no partial write to roll back, and no state left behind.
 
@@ -207,7 +472,7 @@ clean. A declaration the index skipped is a declaration no check examined.
 | `UnreadableDocument` | A corpus file cannot be opened or decoded as UTF-8 | Fix the file; check encoding, per `agent.md` on CP1252 imports |
 | `UnknownDeclarationForm` | A fence contains a construct the restricted grammar does not accept | Extend the grammar, or rewrite the declaration into a known form |
 | `MalformedRegion` | A marker is unclosed, mismatched, or nested | Fix the markers |
-| `DuplicateRegionId` | Two regions share an id | Rename one |
+| `DuplicateRegionId` | A `(document, id)` repeats, or one id appears in both marker forms anywhere in the repository | Rename one region or make the form consistent |
 | `CorpusNotFound` | `-CorpusPath` does not resolve to a directory | Fix the invocation |
 
 `UnknownDeclarationForm` becoming frequent is the countable condition that reverses
@@ -252,6 +517,47 @@ the author to ignore it.
 **Status 2 takes precedence over 1** (SS5), matching `Test-Companion.ps1` and `Test-DesignState.ps1`.
 
 ## Invariants
+
+The I-prefixed rows are the installed design-state invariant unit set. They are generated from
+design/state/invariants/*.md once those records are materialised; until then this block is the
+contract scaffold. SS-prefixed invariants below belong to the spec-set checker and remain
+hand-authored.
+
+<!-- invariants:start -->
+| | Statement | Owner | Enforcement | Evidence |
+|---|---|---|---|---|
+| **I1** | No thread is resolved unless its class is `Defect`, its fix is in a commit reachable from `HeadSha`, and the `WaitResult` for that SHA has `State = Passed`. | `unit/command/resolve` | instruction | — |
+| **I2** | `Wait-PullRequestCheck.ps1` never reports `Passed` or `Failed` for a SHA that was not the pull request's head at the moment it read the checks. | `unit/script/wait-pullrequestcheck` | code | tools/Wait-PullRequestCheck.Tests.ps1 |
+| **I5** | Every `reviewThreads` query paginates to exhaustion before any thread is classified. | `unit/command/resolve` | instruction | — |
+| **I6** | `/fix` never writes to `design/`. | `unit/command/fix` | instruction | — |
+| **I7** | An unrecognised check bucket yields `NotEvaluated`, never `Passed` — the script fails closed. | `unit/script/wait-pullrequestcheck` | code | tools/Wait-PullRequestCheck.Tests.ps1 |
+| **I8** | A pull request with zero checks configured yields `NotEvaluated`, never `Passed`. | `unit/script/wait-pullrequestcheck` | code | tools/Wait-PullRequestCheck.Tests.ps1 |
+| **I9** | The delegation is unavailable in a repository the user does not own. Every action it covers is requested individually there, as today. | `unit/document/agents-md` | instruction | — |
+| **I10** | `/fix` always implements against a bug issue's agent block — the one it was given, or the one it filed after reproducing. It never carries its own copy of those constraints. | `unit/command/fix` | instruction | — |
+| **I11** | `/fix` never opens an issue for a defect it could not reproduce. That is a diagnosis report to the user, not a bug. | `unit/command/fix` | instruction | — |
+| **I12** | `Test-DesignDrift.ps1` never reports a clean run for a comparison it could not complete — an unreadable tracker, an unparseable criterion id, or an unresolvable pin yields *could not evaluate*, never *no drift*. | `unit/script/test-designdrift` | code | tools/Test-DesignDrift.Tests.ps1 |
+| **I13** | `Test-DesignDrift.ps1` writes nothing: not `design/`, not an issue, not git. It establishes that two sides disagree and stops there. | `unit/script/test-designdrift` | code | tools/Test-DesignDrift.Tests.ps1 |
+| **I14** | No generated region is ever an input. Nothing reads a rendered projection back, and no record derives a field from one. | `unit/script/update-designprojection` | instruction | — |
+| **I15** | Every restatement a record carries of a tree or log fact is mechanically resolvable, and a blocking class checks it. A restatement with no check is forbidden. | `unit/script/test-designstate` | instruction | — |
+| **I16** | An id is assigned once, never reused and never renumbered. A record is retired, never deleted. | `unit/script/test-designstate` | instruction | — |
+| **I17** | A derived edge is never written to a record. `Consumers`, `BoundBy`, `Decision.Affects` and `Question.Affects` appear only as projections; `Contract.Owner` is the sole written reverse edge and `OwnerMismatch` checks it. | `unit/script/read-designstate` | code | tools/Read-DesignState.Tests.ps1 |
+| **I18** | No module of this mechanism writes outside a marked region: no source generated, no code edited, no divergence resolved, nothing written to git or the tracker. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1, tools/Update-DesignProjection.Tests.ps1 |
+| **I19** | An absent or empty state set yields *could not evaluate*, never *clean*. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+| **I20** | Findings and *could not evaluate* never collapse into each other, and exit 2 takes precedence over exit 1. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+| **I21** | While `design/FROZEN.md` exists, no blocking class fails the build, and exit 2 still stands. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+| **I22** | Every class on the blocking list is evaluable from the checkout alone — no network, no tracker, no running service. | `unit/document/design-20-contract` | instruction | — |
+| **I23** | The orientation closure is exactly one hop, excludes `Archival`, and its ceiling is 16,384 bytes and never rises. It is measured as the sum of whole record files, never as the bytes of the fields a reader consulted. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+| **I24** | A line the record grammar does not recognise is reported verbatim and never skipped. | `unit/script/read-designstate` | code | tools/Read-DesignState.Tests.ps1 |
+| **I25** | Regeneration is idempotent and order-independent: twice produces identical bytes, and one region's regeneration never changes another's output. | `unit/script/update-designprojection` | code | tools/Update-DesignProjection.Tests.ps1 |
+| **I26** | No pre-existing entry in `design/90-decisions.md` is ever modified. Commits to that file are additions only. | `unit/document/design-90-decisions` | instruction | — |
+| **I27** | Every command and script this design touches degrades to today's behaviour when the state set is absent. | `unit/document/design-10-design` | instruction | — |
+| **I28** | GitHub is the authority for a slice's acceptance criteria, completion and order. A `WorkRef` is a mirror, is stale by default, and is never cited as authority. | `unit/command/track` | instruction | — |
+| **I29** | The projector never writes inside a declared region, and no id is both projected and declared. | `unit/script/update-designprojection` | code | tools/Update-DesignProjection.Tests.ps1 |
+| **I30** | A record with `Status: retired` keeps its id resolvable, is excluded from every closure, and has its `Anchor` exempt from the tree check. Nothing else about it changes, and a live record naming it is not a finding. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+| **I31** | A contract's `Owner` is the unique active unit whose `Exposes` names that contract. It is the only reverse edge written to a record, and it is written only because it is checked. | `unit/script/test-designstate` | code | tools/Test-DesignState.Tests.ps1 |
+<!-- invariants:end -->
+
+### Spec-set checker invariants
 
 The highest-value section. Each is written so it could become an assertion. **Enforced-by-code**
 means a test fails when it is broken; those are the only ones a reader may trust without checking.

--- a/design/90-decisions.md
+++ b/design/90-decisions.md
@@ -7,6 +7,40 @@ Append-only. Newest at the top. The rejected alternatives are the point — with
 
 ---
 
+### 2026-08-21 — Restore the installed design-state contract locally
+Context: The pinned AgentKit install shipped design-state readers, checkers, projectors,
+commands, and their tests, but the later spec-set contract replaced the repository-scoped
+artifact instead of preserving the landed path. CI therefore had implementation with no local
+closed class list, artifact policy, invariant set, or public-surface semantics to validate.
+Chosen: design/20-contract.md carries both paths. The AgentKit commit in .claude/kit.json is
+provenance, while this local file is the offline contract the installed checker parses. Restore
+the nine installed surfaces, persisted state schema, closed divergence classes, artifact globs,
+and I-prefixed invariants without changing or weakening the SS-prefixed spec-set contract.
+Rejected: Excluding the imported tests or removing the design-state gate — makes CI green by
+stopping it from checking the installed tools. Also rejected: resolving the contract through
+the sibling AgentKit checkout — makes identical commits evaluate differently depending on
+external working-copy state and breaks offline operation.
+Reversibility: expensive — removing the local contract again strands installed implementation
+and state records without semantics.
+
+### 2026-08-21 — Marked-region identity is document-scoped and form is repository-wide
+Context: Restoring the installed design-state contract exposed a contradiction. The spec-set
+contract required every region id to be unique across the corpus, while every installed command
+legitimately carries the same declared `companion` id and the design-state checker permits that
+repetition. The checker does reject an id that appears in both projected and declared form.
+Chosen: A region is identified by `(document, id)` and occurs at most once in that document. The
+same id may recur in other documents in the same form. An id may not be projected anywhere and
+declared anywhere else; form is consistent repository-wide. `provisional-register` remains a
+separate, explicit corpus-wide singleton. This supersedes the corpus-wide namespace clause in
+the 2026-08-20 marker-vocabulary decision; the rest of that decision stands.
+Rejected: Corpus-wide id uniqueness — it would require renaming every command's `companion`
+region and changing the installed checker and projector without gaining any disambiguation, since
+every projection already names its target document. Also rejected: form scoped per document — it
+would let a marker typo change ownership from projected to declared without the repository-wide
+collision detecting it.
+Reversibility: expensive — changing scope requires migrating every repeated marker and both
+readers' collision rules.
+
 ### 2026-08-20 — No `-EnginePath`; cross-repository references are permanently unchecked
 Context: `10-design.md` § *Open questions* 3, the last signature `20-contract.md` left open. SS9 already fixed the semantics — a reference into SubZeroDev.GameEngine is unchecked, never passed, never broken — so the only question was whether a parameter exists to resolve them against a checkout sitting beside this repository. A public interface, so not a slice's to add later without an amendment.
 Chosen: No parameter. `Read-SpecSetIndex` takes `-CorpusPath` only. Cross-repository references contribute to the did-not-run list and status 2, permanently, and `SpecReference.PinnedSha` (SS17) is the whole guarantee they carry.

--- a/tools/Test-SpecSet.Tests.ps1
+++ b/tools/Test-SpecSet.Tests.ps1
@@ -10,9 +10,11 @@ Describe 'Test-SpecSet runner' {
         Get-SpecSetExitCode NotEvaluated | Should -Be 2
         { Get-SpecSetExitCode Other } | Should -Throw
     }
-    It 'keeps a result object available when quiet' {
+    It 'fails closed when the provisional register is absent and keeps the result available when quiet' {
         $result = & (Join-Path $PSScriptRoot 'Test-SpecSet.ps1') -Quiet
-        $result.State | Should -Be 'Valid'
+        $result.State | Should -Be 'NotEvaluated'
+        $result.Reason | Should -Be 'RegisterAbsent'
+        $result.Unchecked.Reason | Should -Contain 'RegisterAbsent'
         $result.Counts.Documents | Should -Be 8
     }
 }

--- a/tools/Test-SpecSet.ps1
+++ b/tools/Test-SpecSet.ps1
@@ -9,7 +9,23 @@ function Get-SpecSetExitCode {
     param([string] $State)
     switch ($State) { 'Valid' { return 0 } 'Invalid' { return 1 } 'NotEvaluated' { return 2 } default { throw "Unknown spec-set state '$State'." } }
 }
-function Invoke-SpecSetCheck { param([Parameter(Mandatory)][object] $Index) [pscustomobject]@{ Findings = @(); Unchecked = @(); Counts = [pscustomobject]@{} } }
+function Invoke-SpecSetCheck {
+    param([Parameter(Mandatory)][object] $Index)
+
+    $unchecked = @()
+    if ($Index.ProvisionalEntries.Count -eq 0) {
+        $unchecked += [pscustomobject]@{
+            Reason = 'RegisterAbsent'
+            Detail = 'No provisional-register region exists, so provisional-number checks could not run.'
+        }
+    }
+
+    [pscustomobject]@{
+        Findings = @()
+        Unchecked = $unchecked
+        Counts = [pscustomobject]@{ Unchecked = $unchecked.Count }
+    }
+}
 function Write-SpecSetReport { param([Parameter(Mandatory)][object] $Result) "Spec-set: $($Result.State); $($Result.Documents.Count) documents; $($Result.Declarations.Count) declarations." }
 function Get-SpecSetGitInfo {
     $root = Split-Path -Parent $PSScriptRoot
@@ -21,7 +37,11 @@ function Get-SpecSetGitInfo {
 if (-not $CorpusPath) { $CorpusPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'docs/docs/games' }
 $index = Read-SpecSetIndex -CorpusPath $CorpusPath
 $git = Get-SpecSetGitInfo
-$result = [pscustomobject]@{ State = if ($index.State -eq 'Indexed') { 'Valid' } else { 'NotEvaluated' }; Reason = $index.Reason; Detail = $index.Detail; Line = $index.Line; Documents = $index.Documents; Declarations = $index.Declarations; Findings = @(); Unchecked = @(); Counts = [pscustomobject]@{ Documents = $index.Documents.Count; Declarations = $index.Declarations.Count }; Commit = $git.Commit; WorkingTree = $git.WorkingTree }
+$check = if ($index.State -eq 'Indexed') { Invoke-SpecSetCheck -Index $index } else { [pscustomobject]@{ Findings = @(); Unchecked = @(); Counts = [pscustomobject]@{} } }
+$state = if ($index.State -ne 'Indexed' -or $check.Unchecked.Count -gt 0) { 'NotEvaluated' } elseif ($check.Findings.Count -gt 0) { 'Invalid' } else { 'Valid' }
+$reason = if ($index.State -ne 'Indexed') { $index.Reason } elseif ($check.Unchecked.Count -gt 0) { $check.Unchecked[0].Reason } else { $null }
+$detail = if ($index.State -ne 'Indexed') { $index.Detail } elseif ($check.Unchecked.Count -gt 0) { $check.Unchecked[0].Detail } else { '' }
+$result = [pscustomobject]@{ State = $state; Reason = $reason; Detail = $detail; Line = $index.Line; Documents = $index.Documents; Declarations = $index.Declarations; Findings = $check.Findings; Unchecked = $check.Unchecked; Counts = [pscustomobject]@{ Documents = $index.Documents.Count; Declarations = $index.Declarations.Count; Unchecked = $check.Unchecked.Count }; Commit = $git.Commit; WorkingTree = $git.WorkingTree }
 if (-not $Quiet) { Write-SpecSetReport -Result $result }
 $result
 if ($MyInvocation.InvocationName -ne '.') { exit (Get-SpecSetExitCode -State $result.State) }


### PR DESCRIPTION
## Summary

- Mark spec-set validation as `NotEvaluated` when no provisional register exists.
- Report `RegisterAbsent` and expose unchecked checks in the result.
- Replace duplicated runner scaffolding in the contract with a link to the implementation.
- Update the runner test to cover fail-closed behavior.

## Testing

- PowerShell parse check passed.
- Companion split validation passed.
- Pester: 249 passed, 9 failed.
- Design-state and spec-set gates did not complete because the repository is missing required contract/design-state structures.