### PR TITLE
Refresh a WorkRef when its issue closes instead of leaving it stuck OPEN

### DIFF
--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -1,29 +1,29 @@
 {
   "gates": [
-  {
-    "name": "Parse-check PowerShell scripts",
-    "status": "Passed",
-    "detail": "Every *.ps1 under the repository parsed with [System.Management.Automation.Language.Parser]::ParseFile with zero parse errors returned."
-  },
-  {
-    "name": "Run Pester tests",
-    "status": "Passed",
-    "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 281, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0. The 5 failures present at 6ced5a2/bcd8fec were a single pre-existing cause (design/state-index.md's outstanding region stale against the live tracker after afb4cf0 updated WorkRef records without re-running the projector) and were cleared by 9ba4f50, which regenerates that projection. That commit changes only the projected `outstanding` table, no hand-authored content."
-  },
-  {
-    "name": "Validate the core/companion split",
-    "status": "Passed",
-    "detail": "./tools/Test-Companion.ps1: Companion split OK - 21 core(s) checked, 0 companion file(s) present, 21 core(s) with no companion. State: Valid. Exit code 0."
-  },
-  {
-    "name": "Check the design state against the tree",
-    "status": "Passed",
-    "detail": "./tools/Test-DesignState.ps1: Findings (0), CouldNotEvaluate (0), ExitCode 0. Largest closure: unit/script/test-designstate, 6122 bytes (ceiling 16384), largest contributor contract/test-designstate. The blocking ProjectionStale finding present before 9ba4f50 is gone."
-  },
-  {
-    "name": "Check the spec set",
-    "status": "DidNotRun",
-    "reason": "./tools/Test-SpecSet.ps1 returned State: NotEvaluated, Reason: RegisterAbsent, Detail: 'No provisional-register region exists, so provisional-number checks could not run.' Exit code 2. Not a defect: design/20-contract.md's Error semantics table names RegisterAbsent as an unchecked reason that forces exit 2 by design (SS5, 'If any check is unchecked, the run exits 2 regardless of findings'). The provisional-register region is S5's territory, not S2's, and main itself has been red for this same reason since S1 added this workflow step. design/30-slices.md's own Contract question 1 already flags SS5's all-unchecked-forces-2 semantics as possibly wrong for the permanent CrossRepositoryUnresolvable case; this run surfaces a second, narrower instance (RegisterAbsent, temporary, clears when S5 lands) that the recorded question's 'S1-S3 and S5-S7 are unaffected' line did not anticipate. That is a contract question for /contract, not a code fix here."
-  }
+    {
+      "name": "Parse-check PowerShell scripts",
+      "status": "Passed",
+      "detail": "All *.ps1 files parsed cleanly via [System.Management.Automation.Language.Parser]::ParseFile."
+    },
+    {
+      "name": "Run Pester tests",
+      "status": "Passed",
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 142.76s. Tests Passed: 301, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0."
+    },
+    {
+      "name": "Validate the core/companion split",
+      "status": "Passed",
+      "detail": "Companion split OK - 21 core(s) checked, 0 companion file(s) present, 21 core(s) with no companion. State: Valid. Exit code 0."
+    },
+    {
+      "name": "Check the design state against the tree",
+      "status": "Passed",
+      "detail": "Findings (0). Reported (12): MirrorStale x9 and WorkStateDivergence x3, all non-blocking (design/20-contract.md: MirrorStale is documented staleness, not a divergence; WorkStateDivergence is non-blocking). Largest closure: unit/script/test-designstate, 6122 bytes (ceiling 16384). Exit code: 0."
+    },
+    {
+      "name": "Check the spec set",
+      "status": "DidNotRun",
+      "reason": "Pre-existing, unrelated to this PR: State=NotEvaluated, Reason=RegisterAbsent. Detail: No provisional-register region exists, so provisional-number checks could not run. This is design/30-slices.md S5's job (issue #12, not yet implemented); the same gap has been failing on main since before this branch was cut."
+    }
   ]
 }

--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,12 +3,12 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "All *.ps1 files parsed cleanly via [System.Management.Automation.Language.Parser]::ParseFile."
+      "detail": "All 33 *.ps1 files parsed cleanly via [System.Management.Automation.Language.Parser]::ParseFile."
     },
     {
       "name": "Run Pester tests",
       "status": "Passed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 142.76s. Tests Passed: 301, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0."
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 260.02s. Tests Passed: 301, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0."
     },
     {
       "name": "Validate the core/companion split",

--- a/tools/Update-WorkMirror.Tests.ps1
+++ b/tools/Update-WorkMirror.Tests.ps1
@@ -204,6 +204,72 @@ Describe 'Update-WorkMirror' {
         }
     }
 
+    Context 'refreshing a WorkRef after its issue closes (#29)' {
+        It 'rewrites an existing record to State: CLOSED once its issue drops out of the open list' {
+            $repo = New-RepoRoot
+            $workDir = Join-Path $repo 'design/state/work'
+            New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $workDir '10.md') -Value "# work/10`nIssue: 10`nTitle: S3 - old title`nState: OPEN`nRank: 10`nMirroredAt: oldsha`nCriteria: S3.1`n"
+            Mock Get-OpenIssueList { [pscustomobject]@{ Issues = @(); Failure = $null } }
+            Mock Get-ProjectItemPositions { $null }
+            Mock Get-CurrentWorkMirrorSha { 'newsha' }
+            Mock Get-IssuesByNumber { @((New-Issue -Number 10 -Title 'S3 - old title' -State 'CLOSED' -Body "- [x] **S3.1** done")) }
+
+            $r = Invoke-WorkMirrorUpdate -RepoPath $repo
+
+            $r.State | Should -Be 'Clean'
+            $text = Get-Content -LiteralPath (Join-Path $workDir '10.md') -Raw
+            $text | Should -Match 'State: CLOSED'
+            $text | Should -Match 'MirroredAt: newsha'
+        }
+
+        It 'only re-fetches issue numbers that already have an on-disk WorkRef, not the whole tracker' {
+            $repo = New-RepoRoot
+            $workDir = Join-Path $repo 'design/state/work'
+            New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $workDir '10.md') -Value "# work/10`nIssue: 10`nTitle: t`nState: OPEN`nRank: 10`nMirroredAt: oldsha`nCriteria:`n"
+            Mock Get-OpenIssueList { [pscustomobject]@{ Issues = @(); Failure = $null } }
+            Mock Get-ProjectItemPositions { $null }
+            Mock Get-CurrentWorkMirrorSha { 'newsha' }
+            Mock Get-IssuesByNumber { @() }
+
+            Invoke-WorkMirrorUpdate -RepoPath $repo | Out-Null
+
+            Should -Invoke Get-IssuesByNumber -Times 1 -ParameterFilter { @($Numbers) -join ',' -eq '10' }
+        }
+
+        It 'leaves an existing record untouched when the closed-issue re-fetch itself cannot resolve it' {
+            $repo = New-RepoRoot
+            $workDir = Join-Path $repo 'design/state/work'
+            New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+            $original = "# work/10`nIssue: 10`nTitle: t`nState: OPEN`nRank: 10`nMirroredAt: oldsha`nCriteria:`n"
+            Set-Content -LiteralPath (Join-Path $workDir '10.md') -Value $original -NoNewline
+            Mock Get-OpenIssueList { [pscustomobject]@{ Issues = @(); Failure = $null } }
+            Mock Get-ProjectItemPositions { $null }
+            Mock Get-CurrentWorkMirrorSha { 'newsha' }
+            Mock Get-IssuesByNumber { @() }
+
+            Invoke-WorkMirrorUpdate -RepoPath $repo | Out-Null
+
+            (Get-Content -LiteralPath (Join-Path $workDir '10.md') -Raw) | Should -Be $original
+        }
+
+        It 'does not re-fetch an open issue that already came back from Get-OpenIssueList' {
+            $repo = New-RepoRoot
+            $workDir = Join-Path $repo 'design/state/work'
+            New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $workDir '9.md') -Value "# work/9`nIssue: 9`nTitle: t`nState: OPEN`nRank: 9`nMirroredAt: oldsha`nCriteria:`n"
+            Mock Get-OpenIssueList { [pscustomobject]@{ Issues = @((New-Issue -Number 9 -Title 't')); Failure = $null } }
+            Mock Get-ProjectItemPositions { $null }
+            Mock Get-CurrentWorkMirrorSha { 'newsha' }
+            Mock Get-IssuesByNumber { throw 'must not be called for a still-open issue' }
+
+            Invoke-WorkMirrorUpdate -RepoPath $repo | Out-Null
+
+            (Get-Content -LiteralPath (Join-Path $workDir '9.md') -Raw) | Should -Match 'MirroredAt: newsha'
+        }
+    }
+
     Context 'invocation shape (S14.6)' {
         It 'is the only script under tools/ that invokes gh issue create, gh label, gh milestone, or git commit' {
             $text = Get-Content -LiteralPath $script:ScriptPath -Raw

--- a/tools/Update-WorkMirror.ps1
+++ b/tools/Update-WorkMirror.ps1
@@ -9,7 +9,10 @@
     label, never a milestone, never git (S14.1). `/track`'s alone; no other command invokes it
     and no other command writes a WorkRef.
 
-    One WorkRef per currently-open issue. `Rank` degrades rather than failing: the issue's
+    One WorkRef per issue this repository has ever mirrored: a currently-open issue is written
+    from the tracker listing, and an issue whose on-disk record predates its closing is
+    re-fetched individually and rewritten with its closed State - never left stuck at OPEN.
+    `Rank` degrades rather than failing: the issue's
     position in the per-repository GitHub Project when one places it, otherwise its milestone
     number, otherwise the issue number itself - falling through is not a finding, and an
     emitted WorkRef never lacks a Rank (S14.3). `Criteria` is read from `- [ ] **<id>**`
@@ -155,6 +158,32 @@ function Get-ProjectItemPositions {
     $positions
 }
 
+#
+# Re-fetches individual issues already mirrored on disk that Get-OpenIssueList no longer
+# returns - the only way a closed issue's WorkRef is ever revisited. Best-effort per issue: one
+# that cannot be read (deleted, network blip) is silently skipped and its existing record is
+# left untouched rather than treated as a could-not-evaluate for the whole run.
+function Get-IssuesByNumber {
+    param([int[]] $Numbers, [string] $Repository)
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    foreach ($number in @($Numbers)) {
+        $ghArgs = @('issue', 'view', "$number", '--json', 'number,title,state,body,milestone')
+        if ($Repository) { $ghArgs += @('-R', $Repository) }
+
+        try {
+            $json = & gh @ghArgs 2>$null
+            if ($LASTEXITCODE -ne 0) { continue }
+        } catch { continue }
+        if ([string]::IsNullOrWhiteSpace(($json -join ''))) { continue }
+
+        try {
+            $results.Add((($json -join "`n") | ConvertFrom-Json))
+        } catch { continue }
+    }
+    @($results)
+}
+
 function Get-CurrentRepoOwnerName {
     param([string] $Repository)
 
@@ -244,8 +273,23 @@ function Invoke-WorkMirrorUpdate {
         New-Item -ItemType Directory -Path $workDir -Force | Out-Null
     }
 
+    $openNumbers = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($issue in $issueList.Issues) { [void]$openNumbers.Add([int]$issue.number) }
+
+    $staleNumbers = [System.Collections.Generic.List[int]]::new()
+    if (Test-Path -LiteralPath $workDir) {
+        foreach ($file in Get-ChildItem -LiteralPath $workDir -Filter '*.md' -File) {
+            $number = 0
+            if ([int]::TryParse($file.BaseName, [ref] $number) -and -not $openNumbers.Contains($number)) {
+                $staleNumbers.Add($number)
+            }
+        }
+    }
+
+    $closedIssues = if ($staleNumbers.Count -gt 0) { Get-IssuesByNumber -Numbers @($staleNumbers) -Repository $Repository } else { @() }
+
     $written = [System.Collections.Generic.List[object]]::new()
-    foreach ($issue in $issueList.Issues) {
+    foreach ($issue in (@($issueList.Issues) + @($closedIssues))) {
         $rank = Get-IssueRank -Issue $issue -ProjectPositions $projectPositions
         $lines = ConvertTo-WorkRefLines -Issue $issue -Rank $rank -Sha $sha
         $file = Join-Path $workDir "$($issue.number).md"


### PR DESCRIPTION
`design/state-index.md`'s outstanding-work list is supposed to reflect what is actually still open, but the script that maintains it never revisited an issue once it closed — a closed issue's mirror record stayed marked `OPEN` forever. Reproduced live this session: issue #10 closed but its record kept reporting `OPEN`.

`Update-WorkMirror.ps1` now re-fetches (best-effort, per issue) any on-disk mirror whose issue dropped out of the open-issue list, and rewrites it with the issue's real, closed state.

Closes #29

### Verified

Ran and passed:
- Parse-check PowerShell scripts — All 33 *.ps1 files parsed cleanly via [System.Management.Automation.Language.Parser]::ParseFile.
- Run Pester tests — Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 260.02s. Tests Passed: 301, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0.
- Validate the core/companion split — Companion split OK - 21 core(s) checked, 0 companion file(s) present, 21 core(s) with no companion. State: Valid. Exit code 0.
- Check the design state against the tree — Findings (0). Reported (12): MirrorStale x9 and WorkStateDivergence x3, all non-blocking (design/20-contract.md: MirrorStale is documented staleness, not a divergence; WorkStateDivergence is non-blocking). Largest closure: unit/script/test-designstate, 6122 bytes (ceiling 16384). Exit code: 0.

Ran and failed: none

Did not run:
- Check the spec set — ./tools/Test-SpecSet.ps1: State=NotEvaluated, Reason=RegisterAbsent. "No provisional-register region exists, so provisional-number checks could not run." Pre-existing and unrelated to this PR — this is design/30-slices.md S5's job (issue #12, not yet implemented), and the same gap has been failing on main since before this branch was cut.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Authority:** issue #29's agent block — the failing test is the specification, no upstream design document
- **Out of scope:** the missing `unit/command/track` / `unit/document/agents-md` closure records (issue #19) — unrelated pre-existing gap
- **Verified by reverting:** `git stash` on `tools/Update-WorkMirror.ps1` reproduces the 4 new test failures (`CommandNotFoundException: Get-IssuesByNumber`); restoring the fix passes them
<!-- agent:end -->
</details>
