### PR TITLE
Fix S18.6 self-test to account for the design freeze downgrading EnforcementUnevidenced

### DIFF
--- a/tools/Test-DesignState.Tests.ps1
+++ b/tools/Test-DesignState.Tests.ps1
@@ -1540,8 +1540,11 @@ Describe 'Test-DesignState against this repository''s own tree' {
             [IO.File]::WriteAllText($supersededPath, $stripped, [Text.UTF8Encoding]::new($false))
 
             $strippedResult = Invoke-DesignStateCheck -RepoPath $script:RepoRoot -Repository 'The-Running-Dev/SubZeroDev.GameOfLife'
-            $strippedResult.ExitCode | Should -Be 1
-            $hit = @($strippedResult.Findings | Where-Object { $_.Class -eq 'EnforcementUnevidenced' -and $_.Subject -eq $supersededId })
+            # design/FROZEN.md exists on this tree, so per design/20-contract.md "The freeze",
+            # EnforcementUnevidenced is downgraded to reported rather than blocking - exit 0,
+            # not 1 (I21).
+            $strippedResult.ExitCode | Should -Be 0
+            $hit = @($strippedResult.Reported | Where-Object { $_.Class -eq 'EnforcementUnevidenced' -and $_.Subject -eq $supersededId })
             $hit.Count | Should -Be 1
             $hit[0].Detail | Should -Match 'SupersededBy'
         } finally {
@@ -1550,6 +1553,7 @@ Describe 'Test-DesignState against this repository''s own tree' {
 
         $restoredResult = Invoke-DesignStateCheck -RepoPath $script:RepoRoot -Repository 'The-Running-Dev/SubZeroDev.GameOfLife'
         (@($restoredResult.Findings | Where-Object { $_.Class -eq 'EnforcementUnevidenced' })).Count | Should -Be 0
+        (@($restoredResult.Reported | Where-Object { $_.Class -eq 'EnforcementUnevidenced' })).Count | Should -Be 0
         $restoredResult.ExitCode | Should -Be 0
         [Convert]::ToBase64String([IO.File]::ReadAllBytes($supersededPath)) | Should -Be ([Convert]::ToBase64String($originalBytes))
         (& git -C $script:RepoRoot status --short) | Should -Be $script:StatusBefore


### PR DESCRIPTION
## Summary

- `tools/Test-DesignState.Tests.ps1`'s S18.6 test expected the pre-freeze exit code (1) and the finding in `.Findings` when stripping `SupersededBy:` from a real superseded decision record.
- `design/FROZEN.md` exists on this tree, and `design/20-contract.md` § *The freeze* specifies that while it exists, every blocking class — including `EnforcementUnevidenced` — is downgraded to reported rather than blocking; exit stays 0 (I21).
- The test predates the freeze marker and was never updated. Fixed it to assert exit 0 and check `.Reported` for the finding while frozen, and to check both `.Findings` and `.Reported` are clear once the record is restored.

Closes #38.

## Test plan

- [x] Reverted the fix and confirmed the test fails with `Expected 1, but got 0.` — same failure CI is showing on main
- [x] Reapplied the fix and confirmed the test passes
- [x] Ran the full `tools/Test-DesignState.Tests.ps1` suite: 123 passed, 0 failed