### PR TITLE
Fix #36 — Return's arc table stops claiming it seeds variables the other arcs read

### DIFF
--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,37 +3,27 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "Parsed every *.ps1 with [System.Management.Automation.Language.Parser]::ParseFile — 33 files checked, all parsed cleanly, no syntax errors."
+      "detail": "All *.ps1 files parsed cleanly with System.Management.Automation.Language.Parser.ParseFile — zero parse errors."
     },
     {
       "name": "Run Pester tests",
-      "status": "Failed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 330, Failed: 1, Skipped: 0, Total: 331, Duration 00:03:22.96. The one failure — Test-DesignState.Tests.ps1 'S18.6: EnforcementUnevidenced rejects this repository's own superseded decision once its SupersededBy line is removed, and clears once it is restored' — asserts 'Expected 1, but got 0.' This is the same pre-existing failure recorded in the S4 verify report (commit 9e25508, 'Record verify report for S4 — 6 of 7 gates pass; S18.6 pre-existing failure tracked as #38'): design/FROZEN.md downgrades every blocking divergence class, including EnforcementUnevidenced, to reported rather than blocking (design/20-contract.md § The freeze), so ExitCode is 0 instead of the 1 this test still expects. The test predates the freeze and was never updated for it. Tracked as issue #38 and unrelated to this branch's changes."
+      "status": "Passed",
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 332, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 79.18s."
     },
     {
       "name": "Validate the core/companion split",
       "status": "Passed",
-      "detail": "Companion split OK - 22 core(s) checked, 0 companion file(s) present, 22 core(s) with no companion. State: Valid. Exit code: 0."
+      "detail": "Companion split OK - 22 core(s) checked, 0 companion file(s) present, 22 core(s) with no companion. State: Valid. Findings: none. Exit 0."
     },
     {
       "name": "Check the design state against the tree",
       "status": "Passed",
-      "detail": "State: Valid. Findings: 0. Reported: 12, all class MirrorStale/WorkStateDivergence on already-merged work items (work/8 through work/36), downgraded to reported by the active design freeze — none blocking. CouldNotEvaluate: 0. Largest closure: unit/script/test-specset, 7258 bytes (ceiling 16384). Exit code: 0."
+      "detail": "State: Valid, Findings: none. 4 non-blocking Reported findings (MirrorStale on work/10-13, WorkStateDivergence on work/8,9,12,13,14, ProjectionStale on design/state-index.md and design/20-contract.md#invariants) downgraded from blocking by the active design freeze (design/FROZEN.md). Largest closure 7258 bytes against a 16384 ceiling. Exit code 0."
     },
     {
       "name": "Check the spec set",
-      "status": "Failed",
-      "detail": "Spec-set: Invalid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked, expected — SubZeroDev.GameEngine references). Findings: 12, all CheckId 'concept' — RngState, GameStatus, CalendarState, PlayerState, EconomyState, WorldState, StatusEffect, PendingEventResponse, GoalState, HistoryEntry, LoggedAction, GameMetadata are each a state-bearing concept with no lifecycle-<Concept> region. This is the intended, on-purpose result of this slice (S6): S6 adds the 'concept' check itself and wraps only 2 of the 14 derived concepts (Opportunity, ScheduledEvent) with lifecycle regions; S7 clears the remaining 12. Commit: 8aca602497650bd9c295f7c250941006a7bc1fb1. WorkingTree: Dirty (untracked .claude/session-costs.tsv, unrelated to this branch's tracked changes). Exit code: 1."
-    },
-    {
-      "name": "docs.ps1 -BuildOnly (Docusaurus image build)",
-      "status": "DidNotRun",
-      "reason": "Docker Desktop is not running locally (`docker info` failed) — this repository's docs build needs Docker and is not CI-gated (no `# verification: true` flag on any docs.ps1-related step in .github/workflows/*.yml), so it was skipped rather than reported as passed."
-    },
-    {
-      "name": "git diff --check",
       "status": "Passed",
-      "detail": "git diff --check exited 0 — no trailing whitespace or conflict markers introduced by this branch."
+      "detail": "Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 0 findings; 0 unchecked. 8 references unresolvable (cross-repository, engine/*.md in SubZeroDev.GameEngine, not checked from this repository). Exit 0."
     }
   ]
 }

--- a/docs/docs/games/bulgaria-adventure.md
+++ b/docs/docs/games/bulgaria-adventure.md
@@ -33,7 +33,7 @@ connected arcs (each with its own state and gated choices, independent of the ot
 | **Inheritance** | Property Inheritance, Village Life, Family Meeting | Branching on prior choices, relationship variables, an ending |
 | **Enterprise** | Starting a Business, Entrepreneur, Ultimate Reward | Accumulating debt/patience, the "It Builds Character" achievement |
 | **Driving** | Driving, BMW Ownership | A short two-scene arc, a "trust the mechanic" flag |
-| **Return** | Expat Returns | Standalone opener; seeds variables the other arcs read |
+| **Return** | Expat Returns | Standalone opener; narratively first, with no mechanism to affect the other arcs |
 
 The MVP builds **only the Bureaucracy arc** (see `engine/MVP.md` § 3 @ `bc74a62a2a0a57c5fd82f337712868b6877bbc6a`); the rest
 follow once the loop is proven.


### PR DESCRIPTION
Closes #36.

## What changed

`docs/docs/games/bulgaria-adventure.md` line 36 (the Return row of the arc table) claimed the arc "seeds variables the other arcs read." No such mechanism exists, and none was built.

## Why

`story-graph`'s `Campaign` has no mechanism for one campaign's `kindState` to be read by another — sessions are per-campaign (`engine/04-core.md` §7). `bulgaria-return.ts` was built fully standalone: its own `statLabels` (Local Knowledge, Old Connections, Homesickness), no `variables` key anywhere. This is also independently confirmed in the GameEngine repo's own reconciliation log (`design/90-decisions.md` § 2026-08-09, "'Return seeds variables the other arcs read' isn't mechanically achievable — confirmed by building it (W28)").

I looked for evidence the cross-arc seeding was an intended-but-unbuilt mechanism rather than aspirational prose — no TODOs, no scaffolding, no design-log entry proposing it. The GameEngine decision entry treats it as a false claim to correct, not a deferred feature. The row now states what's actually true and checkable: Return is a standalone, narratively-first opener with no effect on the other arcs.

### Verified

Ran and passed:
- Parse-check PowerShell scripts — all `*.ps1` parsed cleanly, zero parse errors
- Run Pester tests — `Invoke-Pester -Path tools`: 332 passed, 0 failed, 0 skipped, 0 not run
- Validate the core/companion split — `./tools/Test-Companion.ps1`: Valid, 22 core(s) checked, 0 findings
- Check the design state against the tree — `./tools/Test-DesignState.ps1`: Valid, 0 blocking findings (4 non-blocking findings downgraded by the active `design/FROZEN.md` freeze — pre-existing, unrelated to this change)
- Check the spec set — `./tools/Test-SpecSet.ps1`: Valid, 8 documents, 936 declarations, 0 findings (8 cross-repository references unresolvable from this repo, as expected)

Ran and failed: none.

Did not run: none — all discovered CI-gated checks ran.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Issue:** #36 — `.github/ISSUE_TEMPLATE/bug.md` agent block; authority `engine/04-core.md` §7 and the built `bulgaria-return.ts`
- **Fixed:** the false mechanical claim in the Return row's Exercises column
- **Left undone:** none — issue fully addressed
<!-- agent:end -->
</details>