### PR TITLE
Fix nested pwsh/gh subprocess output corrupting non-ASCII characters

### DIFF
--- a/design/state-index.md
+++ b/design/state-index.md
@@ -157,10 +157,6 @@ This document is a navigation view generated from `design/state/`. Edit the reco
 <!-- outstanding:start -->
 | Rank | Issue | Title | Criteria | Mirrored at |
 |---|---|---|---|---|
-| 4 | #11 | S4 — Every reference resolves, and every claim about the engine repository pins a commit | S4.1, S4.2, S4.3, S4.4, S4.5, S4.6, S4.7, S4.8 | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
-| 6 | #13 | S6 — Everything the game keeps in state is counted, and told what it must say | S6.1, S6.2, S6.3, S6.4, S6.5 | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
-| 7 | #14 | S7 — The missing lifecycles are written | S7.1, S7.2, S7.3 | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
-| 19 | #19 | Restore missing design-state closure records | — | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
-| 35 | #35 | bulgaria-adventure.md assigns Enterprise an achievement the built arc does not have | — | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
-| 36 | #36 | bulgaria-adventure.md says the Return arc seeds variables the other arcs read; no such mechanism exists | — | `6d257d42d77ac1988281ac0efdd03e2c398bcbfb` |
+| 19 | #19 | Restore missing design-state closure records | — | `3e6c2c2d768540ca2da5f7160dedcb05366535cb` |
+| 44 | #44 | Three commands cite design/10-design.md § Record, which does not exist | — | `3e6c2c2d768540ca2da5f7160dedcb05366535cb` |
 <!-- outstanding:end -->

--- a/tools/Test-DesignState.ps1
+++ b/tools/Test-DesignState.ps1
@@ -947,9 +947,31 @@ function Invoke-Projector {
         return [pscustomobject]@{ Ran = $false; Detail = 'tools/Update-DesignProjection.ps1 does not exist'; Regions = @() }
     }
     try {
-        $raw = & pwsh -NoProfile -File $projectorPath -Path $RepoPath -DryRun 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            return [pscustomobject]@{ Ran = $false; Detail = "exited $LASTEXITCODE"; Regions = @() }
+        # Invoke via Process, not the `&` call operator: PowerShell decodes a captured
+        # child's stdout using [Console]::OutputEncoding, which on Windows defaults to the
+        # OEM code page (e.g. ibm437) rather than the UTF-8 the projector writes. Left
+        # unset, every non-ASCII byte the projector renders (an em dash, a section sign)
+        # comes back mis-decoded, and every region comparison below reports a false
+        # ProjectionStale (the same class of bug tools/Sync-Kit.ps1's Invoke-GitRaw exists
+        # to avoid for git).
+        $psi = [System.Diagnostics.ProcessStartInfo]::new()
+        $psi.FileName = 'pwsh'
+        $psi.ArgumentList.Add('-NoProfile')
+        $psi.ArgumentList.Add('-File')
+        $psi.ArgumentList.Add($projectorPath)
+        $psi.ArgumentList.Add('-Path')
+        $psi.ArgumentList.Add($RepoPath)
+        $psi.ArgumentList.Add('-DryRun')
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.UseShellExecute = $false
+        $psi.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $raw = $proc.StandardOutput.ReadToEnd()
+        $proc.StandardError.ReadToEnd() | Out-Null
+        $proc.WaitForExit()
+        if ($proc.ExitCode -ne 0) {
+            return [pscustomobject]@{ Ran = $false; Detail = "exited $($proc.ExitCode)"; Regions = @() }
         }
     } catch {
         return [pscustomobject]@{ Ran = $false; Detail = $_.Exception.Message; Regions = @() }

--- a/tools/Update-DesignProjection.ps1
+++ b/tools/Update-DesignProjection.ps1
@@ -47,6 +47,13 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Without this, a non-console stdout (redirected to a file, or captured by a parent process -
+# exactly how -DryRun is consumed) falls back to the OS's OEM code page, which lacks characters
+# like an em dash or a section sign - .NET then best-fit-substitutes each one (an em dash
+# becomes a plain hyphen) before the bytes ever leave this process, so no amount of fixing the
+# caller's own decoding can recover them.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
 $script:ReaderPath = Join-Path $PSScriptRoot 'Read-DesignState.ps1'
 if (-not (Test-Path -LiteralPath $script:ReaderPath)) {
     throw "tools/Read-DesignState.ps1 not found beside tools/Update-DesignProjection.ps1 at $script:ReaderPath"


### PR DESCRIPTION
Fixes #46.

## Summary

`tools/Update-DesignProjection.ps1` never set `[Console]::OutputEncoding`, so with stdout redirected (no real console attached — exactly how `-DryRun` is consumed by a caller) .NET fell back to the OS's OEM code page and best-fit-substituted non-ASCII characters (an em dash became a plain hyphen) before the bytes ever left the process. Independently, `tools/Test-DesignState.ps1`'s `Invoke-Projector` captured that child's stdout via the `&` call operator, which decodes using the *parent's* own OEM-default `[Console]::OutputEncoding` — corrupting even correctly-emitted UTF-8 a second way (the `em dash → "ΓÇö"` mojibake pattern `tools/Sync-Kit.ps1`'s `Invoke-GitRaw`/`Test-EncodingCorruptionOf` already exists to guard against for `git`, from #20/a24541e).

Both together caused `Test-DesignState.Tests.ps1`'s real-repository checks (`S7.9`, `S12.5`, `S11.4/S11.5`) to report false `ProjectionStale` findings against this repo's own tree, and `S18.6` failed as a downstream consequence.

## Fix

- `Update-DesignProjection.ps1`: set `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` at the top of the script, so it always emits correct UTF-8 on stdout regardless of caller.
- `Test-DesignState.ps1`'s `Invoke-Projector`: replaced the `&`-operator capture with an explicit `System.Diagnostics.Process` invocation with `StandardOutputEncoding` forced to UTF-8 (mirroring `Invoke-GitRaw`'s existing precedent), so the parent decodes correctly too.
- Regenerated `design/state-index.md`'s `outstanding` region, which had gone stale after a prior commit closed several `WorkRef`s without re-running the projector.

Also fixed, ahead of this branch, on `main`: hand-repaired the pre-existing mojibake corruption (`ΓÇö`, `┬º`) in `design/state/work/*.md` that this same bug class (very likely via `Update-WorkMirror.ps1`'s identical `& gh` subprocess pattern) had already baked into the tree.

## Out of scope

`tools/Update-WorkMirror.ps1`'s `& gh ...` calls have the identical parent-side decoding defect but no currently-failing test exercises it — noted in #46 as a related, separately-scoped follow-up, not fixed here.

### Verified
Ran and passed:
- Parse-check PowerShell scripts — every `*.ps1` parsed with `[System.Management.Automation.Language.Parser]::ParseFile`, no syntax errors
- Run Pester tests — `Invoke-Pester -Path tools`: 332 passed, 0 failed, 0 skipped, 0 not-run
- Validate the core/companion split — `./tools/Test-Companion.ps1`: Valid, 0 findings
- Check the design state against the tree — `./tools/Test-DesignState.ps1`: Valid, 0 blocking findings, 12 non-blocking `MirrorStale` reports (expected — `MirroredAt` names the parent commit, not this branch's own, on every unmerged `WorkRef`), 0 could-not-evaluate
- Check the spec set — `./tools/Test-SpecSet.ps1`: Valid, 0 findings, working tree clean
- `git diff --check` — exited 0, no trailing-whitespace or conflict-marker issues

Ran and failed: none

Did not run:
- `docs.ps1 -BuildOnly` (Docusaurus image build) — not CI-gated (no `# verification: true` flag on any `docs.ps1`-related step in `.github/workflows/*.yml`) and needs Docker Desktop, unavailable in this session

Regression verification (this fix specifically): reverted the two `tools/` changes (`git stash`) and re-ran `Invoke-Pester -Path tools` — reproduced the exact same 4 failures (`S7.9`, `S12.5`, `S11.4/S11.5`, `S18.6`). Restored the fix (`git stash pop`) — back to 332 passed, 0 failed.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

**Bug:** #46 — no upstream slice; this issue is the specification.
**Authority:** `tools/Test-DesignState.Tests.ps1` (`S7.9`, `S12.5`, `S11.4/S11.5`).
**Criteria met:** all four `Done when` checks — tests pass, and reverting reproduces the failure.
<!-- agent:end -->
</details>
