### PR TITLE
Refresh work mirror after /track sync

### DIFF
--- a/design/state/work/10.md
+++ b/design/state/work/10.md
@@ -3,5 +3,5 @@ Issue: 10
 Title: S3 — The two documents stop being able to disagree about the types they both describe
 State: CLOSED
 Rank: 3
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S3.1, S3.2, S3.3, S3.4, S3.5, S3.6, S3.7, S3.8, S3.9, S3.10

--- a/design/state/work/11.md
+++ b/design/state/work/11.md
@@ -3,5 +3,5 @@ Issue: 11
 Title: S4 — Every reference resolves, and every claim about the engine repository pins a commit
 State: CLOSED
 Rank: 4
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S4.1, S4.2, S4.3, S4.4, S4.5, S4.6, S4.7, S4.8

--- a/design/state/work/12.md
+++ b/design/state/work/12.md
@@ -3,5 +3,5 @@ Issue: 12
 Title: S5 — Every provisional number says why it is deferred and what would settle it
 State: CLOSED
 Rank: 5
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S5.1, S5.2, S5.3, S5.4, S5.5, S5.6

--- a/design/state/work/13.md
+++ b/design/state/work/13.md
@@ -3,5 +3,5 @@ Issue: 13
 Title: S6 — Everything the game keeps in state is counted, and told what it must say
 State: CLOSED
 Rank: 6
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S6.1, S6.2, S6.3, S6.4, S6.5

--- a/design/state/work/14.md
+++ b/design/state/work/14.md
@@ -3,5 +3,5 @@ Issue: 14
 Title: S7 — The missing lifecycles are written
 State: CLOSED
 Rank: 7
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S7.1, S7.2, S7.3

--- a/design/state/work/19.md
+++ b/design/state/work/19.md
@@ -3,5 +3,5 @@ Issue: 19
 Title: Restore missing design-state closure records
 State: OPEN
 Rank: 19
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: 

--- a/design/state/work/26.md
+++ b/design/state/work/26.md
@@ -3,5 +3,5 @@ Issue: 26
 Title: Read-SpecSetIndex fails closed incorrectly for a shallow fixture path
 State: CLOSED
 Rank: 26
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: 

--- a/design/state/work/35.md
+++ b/design/state/work/35.md
@@ -3,5 +3,5 @@ Issue: 35
 Title: bulgaria-adventure.md assigns Enterprise an achievement the built arc does not have
 State: CLOSED
 Rank: 35
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: 

--- a/design/state/work/36.md
+++ b/design/state/work/36.md
@@ -3,5 +3,5 @@ Issue: 36
 Title: bulgaria-adventure.md says the Return arc seeds variables the other arcs read; no such mechanism exists
 State: CLOSED
 Rank: 36
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: 

--- a/design/state/work/44.md
+++ b/design/state/work/44.md
@@ -3,5 +3,5 @@ Issue: 44
 Title: Three commands cite design/10-design.md § Record, which does not exist
 State: OPEN
 Rank: 44
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: 

--- a/design/state/work/8.md
+++ b/design/state/work/8.md
@@ -3,5 +3,5 @@ Issue: 8
 Title: S1 — The spec set is read end to end, or the run stops and points at the line
 State: CLOSED
 Rank: 1
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S1.1, S1.2, S1.3, S1.4, S1.5, S1.6, S1.7, S1.8, S1.9, S1.10

--- a/design/state/work/9.md
+++ b/design/state/work/9.md
@@ -3,5 +3,5 @@ Issue: 9
 Title: S2 — Every push runs the checks
 State: CLOSED
 Rank: 2
-MirroredAt: f15f844bdbf12398a21d038c0a670143ee0f39af
+MirroredAt: 0d1d6acf26e7cb1201de717c4f280918a36c885f
 Criteria: S2.1, S2.2, S2.3, S2.4, S2.5


### PR DESCRIPTION
## Summary
- /track ran a design drift check (0 slices compared, 0 findings) and refreshed the work mirror
- 12 WorkRef records in design/state/work/ updated with new MirroredAt commit stamps

## Test plan
- N/A — mechanical MirroredAt stamp refresh only