### PR TITLE
Refresh work mirror after /track sync

### DIFF
--- a/design/state-index.md
+++ b/design/state-index.md
@@ -161,6 +161,7 @@ This document is a navigation view generated from `design/state/`. Edit the reco
 <!-- outstanding:start -->
 | Rank | Issue | Title | Criteria | Mirrored at |
 |---|---|---|---|---|
-| 19 | #19 | Restore missing design-state closure records | — | `a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d` |
-| 44 | #44 | Three commands cite design/10-design.md § Record, which does not exist | — | `a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d` |
+| 19 | #19 | Restore missing design-state closure records | — | `20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7` |
+| 44 | #44 | Three commands cite design/10-design.md § Record, which does not exist | — | `20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7` |
+| 62 | #62 | Every /track work-mirror refresh leaves the build red | — | `20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7` |
 <!-- outstanding:end -->

--- a/design/state/work/10.md
+++ b/design/state/work/10.md
@@ -3,5 +3,5 @@ Issue: 10
 Title: S3 — The two documents stop being able to disagree about the types they both describe
 State: CLOSED
 Rank: 3
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S3.1, S3.2, S3.3, S3.4, S3.5, S3.6, S3.7, S3.8, S3.9, S3.10

--- a/design/state/work/11.md
+++ b/design/state/work/11.md
@@ -3,5 +3,5 @@ Issue: 11
 Title: S4 — Every reference resolves, and every claim about the engine repository pins a commit
 State: CLOSED
 Rank: 4
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S4.1, S4.2, S4.3, S4.4, S4.5, S4.6, S4.7, S4.8

--- a/design/state/work/12.md
+++ b/design/state/work/12.md
@@ -3,5 +3,5 @@ Issue: 12
 Title: S5 — Every provisional number says why it is deferred and what would settle it
 State: CLOSED
 Rank: 5
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S5.1, S5.2, S5.3, S5.4, S5.5, S5.6

--- a/design/state/work/13.md
+++ b/design/state/work/13.md
@@ -3,5 +3,5 @@ Issue: 13
 Title: S6 — Everything the game keeps in state is counted, and told what it must say
 State: CLOSED
 Rank: 6
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S6.1, S6.2, S6.3, S6.4, S6.5

--- a/design/state/work/14.md
+++ b/design/state/work/14.md
@@ -3,5 +3,5 @@ Issue: 14
 Title: S7 — The missing lifecycles are written
 State: CLOSED
 Rank: 7
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S7.1, S7.2, S7.3

--- a/design/state/work/19.md
+++ b/design/state/work/19.md
@@ -3,5 +3,5 @@ Issue: 19
 Title: Restore missing design-state closure records
 State: OPEN
 Rank: 19
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: 

--- a/design/state/work/26.md
+++ b/design/state/work/26.md
@@ -3,5 +3,5 @@ Issue: 26
 Title: Read-SpecSetIndex fails closed incorrectly for a shallow fixture path
 State: CLOSED
 Rank: 26
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: 

--- a/design/state/work/35.md
+++ b/design/state/work/35.md
@@ -3,5 +3,5 @@ Issue: 35
 Title: bulgaria-adventure.md assigns Enterprise an achievement the built arc does not have
 State: CLOSED
 Rank: 35
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: 

--- a/design/state/work/36.md
+++ b/design/state/work/36.md
@@ -3,5 +3,5 @@ Issue: 36
 Title: bulgaria-adventure.md says the Return arc seeds variables the other arcs read; no such mechanism exists
 State: CLOSED
 Rank: 36
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: 

--- a/design/state/work/44.md
+++ b/design/state/work/44.md
@@ -3,5 +3,5 @@ Issue: 44
 Title: Three commands cite design/10-design.md § Record, which does not exist
 State: OPEN
 Rank: 44
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: 

--- a/design/state/work/62.md
+++ b/design/state/work/62.md
@@ -1,0 +1,7 @@
+# work/62
+Issue: 62
+Title: Every /track work-mirror refresh leaves the build red
+State: OPEN
+Rank: 62
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
+Criteria: 

--- a/design/state/work/8.md
+++ b/design/state/work/8.md
@@ -3,5 +3,5 @@ Issue: 8
 Title: S1 — The spec set is read end to end, or the run stops and points at the line
 State: CLOSED
 Rank: 1
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S1.1, S1.2, S1.3, S1.4, S1.5, S1.6, S1.7, S1.8, S1.9, S1.10

--- a/design/state/work/9.md
+++ b/design/state/work/9.md
@@ -3,5 +3,5 @@ Issue: 9
 Title: S2 — Every push runs the checks
 State: CLOSED
 Rank: 2
-MirroredAt: a6d4811cc32b8d9c1e9cf5439d9f011c445fa29d
+MirroredAt: 20124ea9b48ad0ee7ab99215a6f1d7cf118bb8a7
 Criteria: S2.1, S2.2, S2.3, S2.4, S2.5


### PR DESCRIPTION
`/track` sync of `design/` against the tracker.

Adds the `WorkRef` record for issue #62 and re-stamps `MirroredAt` on the twelve
existing records. Regenerates the `outstanding` region of `design/state-index.md`
so the projection matches the records — without it `ProjectionStale` fires, which
is blocking, and is the coupling tracked as #62.

### Verified
- `tools/Test-DesignDrift.ps1` — exit 0. Slices compared: 0, findings 0, could not evaluate 0.
- `tools/Update-WorkMirror.ps1` — exit 0. Wrote 13 WorkRef records.
- `tools/Update-DesignProjection.ps1` — exit 0.
- `tools/Test-DesignState.ps1` — exit 0. Findings 0, reported 0, could not evaluate 0. Largest closure `unit/script/test-specset`, 8389 bytes against a 16384 ceiling.

Did not run: the full Pester suite and the spec-set checker — no source under test changed, only generated state records and the region they project into.

### Note
`design/state/work/62.md` carries a trailing space after `Criteria:`, which
`git diff --check` flags. It is `Update-WorkMirror.ps1`'s output for an issue with
no criteria, and matches the already-committed records for #19 and #44. Committed
as generated rather than hand-stripped.