### PR TITLE
Fix WorkStateDivergence non-ASCII title false-positive

### DIFF
--- a/tools/Test-DesignState.Tests.ps1
+++ b/tools/Test-DesignState.Tests.ps1
@@ -956,10 +956,9 @@ Describe 'Test-DesignState: the tracker classes (S5.11)' {
         Mock -CommandName Get-CurrentCommitSha -MockWith { 'currentsha' }
         Mock -CommandName Test-CommitIsAncestor -MockWith { 'Ancestor' }
         $script:TrackerGhArgs = @()
-        Mock -CommandName gh -MockWith {
-            $script:TrackerGhArgs = @($args)
-            $global:LASTEXITCODE = 0
-            '{"title":"Tracked title","state":"OPEN"}'
+        Mock -CommandName Invoke-Gh -MockWith {
+            $script:TrackerGhArgs = @($Arguments)
+            [pscustomobject]@{ ExitCode = 0; StdOut = '{"title":"Tracked title","state":"OPEN"}' }
         }
 
         $ref = New-Record -Id 'work/42' -Kind 'WorkRef' -Scalars @{
@@ -970,6 +969,42 @@ Describe 'Test-DesignState: the tracker classes (S5.11)' {
         $result.CouldNotEvaluate | Should -BeNullOrEmpty
         $script:TrackerGhArgs | Should -Contain '-R'
         $script:TrackerGhArgs | Should -Contain 'owner/repository'
+    }
+
+    Context 'Invoke-Gh decodes the child process output as UTF-8 regardless of the console default (#65)' {
+        <#
+          gh itself needs auth this environment cannot guarantee, so this points Invoke-Gh's
+          -Command at git instead - a process this repository can always run, and one whose
+          "show a blob containing an em dash" output exercises the exact same
+          ProcessStartInfo/StandardOutputEncoding path Invoke-Gh uses for gh. The `&` call
+          operator Invoke-Gh replaced decoded a captured child's stdout using
+          [Console]::OutputEncoding, which on Windows defaults to the OEM code page rather
+          than the UTF-8 the child actually writes - this is the regression test for that:
+          it fails under the pre-fix `&`-based implementation and passes under Invoke-Gh.
+        #>
+        BeforeAll {
+            $script:EncodingRepo = Join-Path $TestDrive 'encoding-repo-65'
+            New-Item -ItemType Directory -Path $script:EncodingRepo -Force | Out-Null
+            & git -C $script:EncodingRepo init --quiet 2>$null
+            & git -C $script:EncodingRepo config user.email 'test@example.com' 2>$null
+            & git -C $script:EncodingRepo config user.name 'Test' 2>$null
+            Set-Content -LiteralPath (Join-Path $script:EncodingRepo 'file.md') -Value "line one em dash `u{2014} end" -NoNewline -Encoding utf8NoBOM
+            & git -C $script:EncodingRepo add file.md 2>$null
+            & git -C $script:EncodingRepo commit -m 'em dash' --quiet 2>$null
+        }
+
+        It 'reads back the em dash intact under a non-UTF-8 console encoding' {
+            $original = [Console]::OutputEncoding
+            try {
+                [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding(437)
+                $result = Invoke-Gh -Command 'git' -Arguments @('-C', $script:EncodingRepo, 'show', 'HEAD:file.md')
+            } finally {
+                [Console]::OutputEncoding = $original
+            }
+
+            $result.ExitCode | Should -Be 0
+            $result.StdOut | Should -Be "line one em dash `u{2014} end"
+        }
     }
 }
 

--- a/tools/Test-DesignState.ps1
+++ b/tools/Test-DesignState.ps1
@@ -1072,6 +1072,29 @@ function Test-CommitIsAncestor {
     }
 }
 
+function Invoke-Gh {
+    param([Parameter(Mandatory)][string[]] $Arguments, [string] $Command = 'gh')
+
+    # Invoke via Process, not the `&` call operator: PowerShell decodes a captured child's
+    # stdout using [Console]::OutputEncoding, which on Windows defaults to the OEM code page
+    # rather than the UTF-8 gh actually writes. Left unset, a non-ASCII byte in an issue title
+    # (an em dash) comes back mis-decoded and WorkStateDivergence's title comparison below
+    # false-positives - the same class of bug Invoke-Projector (above) and
+    # Update-WorkMirror.ps1's own Invoke-Gh already exist to avoid.
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $Command
+    foreach ($arg in $Arguments) { $psi.ArgumentList.Add($arg) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $proc.StandardError.ReadToEnd() | Out-Null
+    $proc.WaitForExit()
+    [pscustomobject]@{ ExitCode = $proc.ExitCode; StdOut = $stdout }
+}
+
 function Test-TrackerAvailable {
     param([string] $Repository)
     $ghArgs = @('issue', 'list', '--state', 'all', '--limit', '1', '--json', 'number')
@@ -1109,13 +1132,13 @@ function Test-TrackerClasses {
             if ([string]::IsNullOrWhiteSpace($number)) { continue }
             $ghArgs = @('issue', 'view', $number, '--json', 'title,state')
             if ($Repository) { $ghArgs += @('-R', $Repository) }
-            $json = & gh @ghArgs 2>$null
-            if ($LASTEXITCODE -ne 0 -or -not $json) {
+            $ghResult = Invoke-Gh -Arguments $ghArgs
+            if ($ghResult.ExitCode -ne 0 -or -not $ghResult.StdOut) {
                 $couldNotEvaluate.Add((New-CouldNotEvaluate -Reason 'TrackerUnavailable' -Detail "could not read issue #$number for $($ref.Id)"))
                 continue
             }
             try {
-                $issue = ($json -join "`n") | ConvertFrom-Json
+                $issue = $ghResult.StdOut | ConvertFrom-Json
             } catch {
                 $couldNotEvaluate.Add((New-CouldNotEvaluate -Reason 'TrackerUnavailable' -Detail "unparseable gh output for issue #$number"))
                 continue


### PR DESCRIPTION
**What changed, and why.** `Test-DesignState.ps1`'s `WorkStateDivergence` title comparison called `gh` via the `&` call operator, which PowerShell decodes using `[Console]::OutputEncoding` — the OEM code page on Windows, not the UTF-8 `gh` actually writes. A byte-identical title with a non-ASCII character (an em dash) came back mis-decoded, so the comparison reported a divergence that did not exist. Adds an `Invoke-Gh` helper using `System.Diagnostics.Process` with an explicit UTF-8 `StandardOutputEncoding` — the same pattern `Update-WorkMirror.ps1`'s own `Invoke-Gh` already uses for the identical bug class (#48) — and routes the issue-view call through it.

Closes #65

### Verified

Ran and passed:
- Parse-check PowerShell scripts — 36 files, all parsed cleanly
- Run Pester tests — 356 passed, 0 failed, 0 skipped (includes the new regression test, confirmed to fail pre-fix and pass post-fix)
- Validate the core/companion split — 22 core(s) checked, 0 findings
- Check the design state against the tree — 0 blocking findings; 14 non-blocking MirrorStale (expected on an unmerged branch)
- Check the spec set — Valid; 936 declarations, 0 findings
- git diff --check — clean

Did not run:
- docs.ps1 -BuildOnly (Docusaurus image build) — not CI-gated, and this change touches no docs/ files

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Bug:** #65 — WorkStateDivergence false-positives on non-ASCII issue titles via the gh call operator
- **Fix:** `tools/Test-DesignState.ps1` — added `Invoke-Gh`, routed the issue-view call through it
- **Regression test:** `tools/Test-DesignState.Tests.ps1` — "reads back the em dash intact under a non-UTF-8 console encoding"; confirmed to fail against the pre-fix `&`-based implementation and pass with the fix
<!-- agent:end -->
</details>