### PR TITLE
chore: refresh work mirror (#62 closed)

### DIFF
--- a/design/state-index.md
+++ b/design/state-index.md
@@ -164,5 +164,4 @@ This document is a navigation view generated from `design/state/`. Edit the reco
 | Rank | Issue | Title | Criteria | Mirrored at |
 |---|---|---|---|---|
 | 44 | #44 | Three commands cite design/10-design.md § Record, which does not exist | — | `c97bb3bf808924068e35788b32a352f0e7cb3d64` |
-| 62 | #62 | Every /track work-mirror refresh leaves the build red | — | `c97bb3bf808924068e35788b32a352f0e7cb3d64` |
 <!-- outstanding:end -->

--- a/design/state/work/62.md
+++ b/design/state/work/62.md
@@ -1,7 +1,7 @@
 # work/62
 Issue: 62
 Title: Every /track work-mirror refresh leaves the build red
-State: OPEN
+State: CLOSED
 Rank: 62
-MirroredAt: c97bb3bf808924068e35788b32a352f0e7cb3d64
+MirroredAt: df02129c1bab6af9a78f64d2bad3daa21edc451e
 Criteria: 


### PR DESCRIPTION
## Summary
- Ran `/track`: no design drift, no outstanding slices in `design/30-slices.md`, `## Open` in `design/90-decisions.md` empty.
- `Update-WorkMirror.ps1` found issue #62 already closed (landed via the kit-sync fix committed as df02129) and updated `design/state/work/62.md` accordingly.
- `Update-DesignProjection.ps1` regenerated `design/state-index.md`'s `outstanding` region, dropping the now-closed #62 row.

## Test plan
- [x] `tools/Test-DesignDrift.ps1` — exit 0, no drift
- [x] `tools/Update-WorkMirror.ps1` — exit 0, 1 record written
- [x] `tools/Update-DesignProjection.ps1` — exit 0