### PR TITLE
S12 — Nothing reaches past the engine's published surface, and nothing reads the published output

### DIFF
--- a/.claude/gates.json
+++ b/.claude/gates.json
@@ -1,6 +1,6 @@
 {
-  "manifestHash": "837dfb78e5457ebb6b232f7ccf1d6f4a67cd4687fb8d2e1bd11a5e2594a3928e",
-  "generated": "2026-08-25",
+  "manifestHash": "6578e09c2a7be8fb00bee3371bf4ef5a2b3d02a67ad9a9ed1cf78bb9aa25498d",
+  "generated": "2026-08-30",
   "gates": [
     {
       "name": "Parse-check PowerShell scripts",
@@ -21,6 +21,22 @@
     {
       "name": "Check the spec set",
       "command": "./tools/Test-SpecSet.ps1"
+    },
+    {
+      "name": "Build the pinned engine",
+      "command": "npm run setup"
+    },
+    {
+      "name": "Typecheck the campaign sources",
+      "command": "npm run typecheck"
+    },
+    {
+      "name": "Test the campaign sources",
+      "command": "npm test"
+    },
+    {
+      "name": "Re-export content and fail if the committed JSON is stale",
+      "command": "npm run export:content && npm run check:clean"
     }
   ]
 }

--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,37 +3,57 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "Parsed every *.ps1 under the repository with [System.Management.Automation.Language.Parser]::ParseFile. 33 files checked, all parsed cleanly, no syntax errors."
+      "detail": "Get-ChildItem -Path . -Recurse -Filter *.ps1 | [System.Management.Automation.Language.Parser]::ParseFile per file. 99 files checked, all parsed cleanly, no syntax errors."
     },
     {
       "name": "Run Pester tests",
       "status": "Passed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 333, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 151.63s. Includes the new Update-WorkMirror.Tests.ps1 regression test for Invoke-Gh's UTF-8 decoding (#48), verified to fail under the pre-fix `&`-based implementation and pass under the fix."
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 312.21s (UserDuration 00:04:45.07)."
     },
     {
       "name": "Validate the core/companion split",
       "status": "Passed",
-      "detail": "Companion split OK - 22 core(s) checked, 0 companion file(s) present, 22 core(s) with no companion. State: Valid. Findings: none. Exit code: 0."
+      "detail": "Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid. Findings: none. Exit code: 0."
     },
     {
       "name": "Check the design state against the tree",
       "status": "Passed",
-      "detail": "State: Valid. Findings (blocking): 0. Reported (non-blocking): 12, all class MirrorStale on work/8 through work/44, each because MirroredAt still names the branch's parent commit 19c07e04 rather than this branch's own commit 9cc1d656 — expected on an unmerged feature branch, not a design freeze or a downgrade (DowngradedCount: 0). CouldNotEvaluate: 0. Largest closure: unit/script/test-specset, 7258 bytes (ceiling 16384). Exit code: 0."
+      "detail": "State: Valid (exit 0). Findings (blocking): 0. Reported (non-blocking): 26, all class MirrorStale on work/8 through work/91, each because MirroredAt still names an earlier commit rather than this branch's own commit a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c, expected on an unmerged feature branch, not a design freeze or a downgrade (DowngradedCount: 0). CouldNotEvaluate: 0. Largest closure: unit/document/design-20-contract, 8601 bytes (ceiling 16384)."
     },
     {
       "name": "Check the spec set",
       "status": "Passed",
-      "detail": "Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 0 findings; 0 unchecked; 8 references unresolvable (cross-repository, engine/*.md in SubZeroDev.GameEngine — the established permanent steady state, not checked from this repository). Commit: 9cc1d656edec088eb5dc3ca5ab75a51edb6eae18. WorkingTree: Clean. Exit code: 0."
+      "detail": "Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 0 findings; 0 unchecked; 8 references unresolvable (cross-repository, engine/*.md in SubZeroDev.GameEngine, not checked from this repository). Commit: a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c. WorkingTree: Dirty at the time this gate ran (only .claude/gates.json, refreshed by this same verify pass for the new content-path gates below; no source file was uncommitted). Exit code: 0."
     },
     {
-      "name": "docs.ps1 -BuildOnly (Docusaurus image build)",
-      "status": "DidNotRun",
-      "reason": "Not CI-gated (no `# verification: true` flag on any docs.ps1-related step in .github/workflows/*.yml). Docker Desktop was available this session, but this change touches no docs/ files, so the build was not run rather than spending an unrelated Docker build cycle on it."
+      "name": "Build the pinned engine",
+      "status": "Passed",
+      "detail": "npm run setup (npm --prefix engine/src/engine ci && npm --prefix engine/src/engine run build) — exit 0. Installed 140 packages in 6s (npm audit reported 1 pre-existing high-severity advisory in the engine submodule's own dependency tree, unrelated to this change and not part of this gate). Engine built via `npm run clean && tsc -p tsconfig.build.json` with no errors."
+    },
+    {
+      "name": "Typecheck the campaign sources",
+      "status": "Passed",
+      "detail": "npm run typecheck (tsc --noEmit) — exit 0, no type errors."
+    },
+    {
+      "name": "Test the campaign sources",
+      "status": "Passed",
+      "detail": "npm test (vitest run) — Test Files 2 passed (2), Tests 11 passed (11), Duration 2.88s. Includes the new src/published-surface.test.ts (4 tests: CP1, CP2 x2, CP3) alongside the existing src/campaigns/stable-life.test.ts (7 tests)."
+    },
+    {
+      "name": "Re-export content and fail if the committed JSON is stale",
+      "status": "Passed",
+      "detail": "npm run export:content && npm run check:clean — exit 0. export-content.ts: 'Exported 1 campaign(s) to content/'. check-clean.mjs: 'content/ matches the sources.' — this slice touches no campaign source, so the committed content/ was already current."
     },
     {
       "name": "git diff --check",
       "status": "Passed",
       "detail": "git diff --check exited 0 — no trailing whitespace or conflict markers on this branch's changes."
+    },
+    {
+      "name": "docs.ps1 -BuildOnly (Docusaurus image build)",
+      "status": "DidNotRun",
+      "reason": "Not CI-gated (no `# verification: true` flag on any docs.ps1-related step in .github/workflows/*.yml). This change touches no docs/ files, so the build was not run rather than spending an unrelated Docker build cycle on it."
     }
   ]
 }

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -948,9 +948,9 @@ fails when the row is broken**, and an em dash means nothing enforces it yet.
 
 | Id | Invariant | Owner | Enforcement | Evidence |
 |---|---|---|---|---|
-| **CP1** | No source in this repository imports the engine by anything other than `@the-running-dev/game-engine` or its `/authoring` subpath, and no relative import escapes this repository's own sources | Campaign sources, Exporter | Code | — |
-| **CP2** | `content/` has exactly one writer, and it writes nowhere else | Exporter | Code | — |
-| **CP3** | Nothing in this repository reads a file under `content/` | All | Code | — |
+| **CP1** | No source in this repository imports the engine by anything other than `@the-running-dev/game-engine` or its `/authoring` subpath, and no relative import escapes this repository's own sources | Campaign sources, Exporter | Code | `src/published-surface.test.ts` |
+| **CP2** | `content/` has exactly one writer, and it writes nowhere else | Exporter | Code | `src/published-surface.test.ts` |
+| **CP3** | Nothing in this repository reads a file under `content/` | All | Code | `src/published-surface.test.ts` |
 | **CP4** | Every campaign builds and the whole set validates before any file is written; a failure before the write phase leaves `content/` byte-identical | Exporter | Code | — |
 | **CP5** | Two exports from the same sources and the same pin produce byte-identical files | Exporter | Code | `.github/workflows/verify.yml`, step *Re-export content and fail if the committed JSON is stale* |
 | **CP6** | Every `.json` under `content/` the publication catalog does not name is removed by the export | Exporter | Code | — |

--- a/src/published-surface.test.ts
+++ b/src/published-surface.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Enforces CP1, CP2 and CP3 (`design/20-contract.md`): nothing under `src/` or `scripts/`
+ * imports past the engine's published surface, nothing but the exporter writes or deletes
+ * under `content/`, and nothing reads a file under `content/`.
+ *
+ * CP1 is the row the submodule makes easy to break by accident — a relative import into
+ * `engine/`'s own source tree typechecks, runs, and passes every other gate, and only fails
+ * once the pin moves or the campaign runs on a published engine version. Static analysis
+ * over the import specifiers is what catches it before that point.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { isBuiltin } from "node:module";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, "..");
+const srcDir = path.join(projectRoot, "src");
+const scriptsDir = path.join(projectRoot, "scripts");
+const contentDir = path.join(projectRoot, "content");
+
+const pkg = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8")) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const declaredPackages = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.devDependencies ?? {}),
+]);
+
+const PUBLISHED_ENGINE_SURFACE = new Set([
+  "@the-running-dev/game-engine",
+  "@the-running-dev/game-engine/authoring",
+]);
+
+/** Every `.ts`/`.mjs` file under `root`, walked recursively. */
+function walk(root: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(root)) {
+    const full = path.join(root, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walk(full));
+    } else if (name.endsWith(".ts") || name.endsWith(".mjs")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = [...walk(srcDir), ...walk(scriptsDir)];
+
+interface ImportSpecifier {
+  readonly specifier: string;
+  readonly line: number;
+}
+
+/** Static import, dynamic `import(...)`, and `export ... from` specifiers — the forms this
+ *  repository's ESM sources can use to reach another module. */
+// The trailing from-clause groups are lazily optional (double-question-mark, prefer zero
+// reps) rather than plain-optional (single question mark, prefer one rep) — a plain
+// single-question-mark quantifier is greedy and, for a side-effect-only import with no
+// from-clause at all, would search forward past it for a from-clause belonging to a later
+// statement instead of matching the specifier right in front of it.
+const SPECIFIER_PATTERN =
+  /(?:\bimport\s+(?:[\s\S]*?\bfrom\s+)??|\bexport\s+(?:[\s\S]*?\bfrom\s+)??|\bimport\s*\()\s*["']([^"']+)["']/g;
+
+function specifiersOf(text: string): ImportSpecifier[] {
+  const found: ImportSpecifier[] = [];
+  for (const match of text.matchAll(SPECIFIER_PATTERN)) {
+    const specifier = match[1];
+    if (specifier === undefined || match.index === undefined) continue;
+    const line = text.slice(0, match.index).split("\n").length;
+    found.push({ specifier, line });
+  }
+  return found;
+}
+
+/** The name a specifier would be declared under in `package.json` — the scope-qualified
+ *  name for a scoped package, the first path segment otherwise. Subpaths of the engine
+ *  package are handled separately, by exact match, since only two are published. */
+function packageNameOf(specifier: string): string {
+  const segments = specifier.split("/");
+  return specifier.startsWith("@") ? segments.slice(0, 2).join("/") : (segments[0] ?? specifier);
+}
+
+function isInside(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+/** Repo-relative, forward-slashed — stable across the host OS's path separator. */
+function relativePosix(file: string): string {
+  return path.relative(projectRoot, file).split(path.sep).join("/");
+}
+
+function isAllowedSpecifier(specifier: string, fileDir: string): boolean {
+  if (PUBLISHED_ENGINE_SURFACE.has(specifier)) return true;
+  if (isBuiltin(specifier)) return true;
+  if (specifier.startsWith(".")) {
+    const resolved = path.resolve(fileDir, specifier);
+    return isInside(resolved, srcDir) || isInside(resolved, scriptsDir);
+  }
+  return declaredPackages.has(packageNameOf(specifier));
+}
+
+describe("the published surface (CP1)", () => {
+  it("imports nothing outside the engine's published surface, Node, a declared package, or this repository's own src/scripts", () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      const fileDir = path.dirname(file);
+      for (const { specifier, line } of specifiersOf(text)) {
+        if (!isAllowedSpecifier(specifier, fileDir)) {
+          violations.push(`${relativePosix(file)}:${line} imports "${specifier}"`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});
+
+/** `node:fs`/`node:fs/promises` (and their bare-specifier equivalents) local bindings for a
+ *  file — named imports, plus a namespace/default alias for the `alias.fn(...)` call form. */
+interface FsBindings {
+  readonly named: Set<string>;
+  readonly aliases: Set<string>;
+}
+
+const FS_MODULES = new Set(["fs", "node:fs", "fs/promises", "node:fs/promises"]);
+const FS_IMPORT_PATTERN =
+  /import\s+(?:(\*\s+as\s+(\w+))|(\w+)|\{([^}]*)\})\s+from\s+["'](fs|node:fs|fs\/promises|node:fs\/promises)["']/g;
+
+function fsBindingsOf(text: string): FsBindings {
+  const named = new Set<string>();
+  const aliases = new Set<string>();
+  for (const match of text.matchAll(FS_IMPORT_PATTERN)) {
+    const [, , namespaceAlias, defaultAlias, namedList] = match;
+    if (namespaceAlias) aliases.add(namespaceAlias);
+    if (defaultAlias) aliases.add(defaultAlias);
+    if (namedList) {
+      for (const part of namedList.split(",")) {
+        const name = part.trim().split(/\s+as\s+/).pop()?.trim();
+        if (name) named.add(name);
+      }
+    }
+  }
+  return { named, aliases };
+}
+
+const WRITE_OR_DELETE_FNS = [
+  "writeFile", "writeFileSync", "mkdir", "mkdirSync", "rm", "rmSync", "rmdir", "rmdirSync",
+  "unlink", "unlinkSync", "appendFile", "appendFileSync", "rename", "renameSync",
+  "copyFile", "copyFileSync", "truncate", "truncateSync", "symlink", "symlinkSync",
+  "link", "linkSync", "chmod", "chmodSync", "chown", "chownSync", "utimes", "utimesSync",
+  "createWriteStream",
+];
+
+const READ_FILE_FNS = ["readFile", "readFileSync", "createReadStream"];
+
+/** Every `name(...)` or `alias.name(...)` call, with the raw (unparsed) argument text. */
+function callsOf(text: string, names: readonly string[], aliases: readonly string[]): string[] {
+  if (names.length === 0) return [];
+  const calls: string[] = [];
+  const bareNames = names.map((n) => `\\b${n}\\s*\\(`);
+  const aliasedNames = aliases.flatMap((a) => names.map((n) => `\\b${a}\\.${n}\\s*\\(`));
+  const pattern = new RegExp([...bareNames, ...aliasedNames].join("|"), "g");
+  for (const match of text.matchAll(pattern)) {
+    const start = match.index! + match[0].length;
+    let depth = 1;
+    let end = start;
+    while (end < text.length && depth > 0) {
+      if (text[end] === "(") depth++;
+      else if (text[end] === ")") depth--;
+      end++;
+    }
+    calls.push(text.slice(start, end - 1));
+  }
+  return calls;
+}
+
+/** The first top-level (paren-depth-0) comma-separated argument, trimmed. */
+function firstArgument(rawArgs: string): string {
+  let depth = 0;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const ch = rawArgs[i];
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    else if (ch === "," && depth === 0) return rawArgs.slice(0, i).trim();
+  }
+  return rawArgs.trim();
+}
+
+describe("the single writer (CP2)", () => {
+  it("is the only file under src/ or scripts/ that writes or deletes a file", () => {
+    const writers: string[] = [];
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      const { named, aliases } = fsBindingsOf(text);
+      const writeNames = WRITE_OR_DELETE_FNS.filter((n) => named.has(n));
+      const calls = callsOf(text, writeNames, [...aliases]);
+      if (calls.length > 0) writers.push(relativePosix(file));
+    }
+    expect(writers).toEqual(["scripts/export-content.ts"]);
+  });
+
+  it("resolves every write and delete the exporter performs under content/", () => {
+    const exporterPath = path.join(scriptsDir, "export-content.ts");
+    const text = readFileSync(exporterPath, "utf8");
+
+    // outputDir must itself be declared as a path.join(..., "content").
+    const outputDirDeclaration = text.match(
+      /const\s+outputDir\s*=\s*path\.join\([^)]*["']content["']\s*\)/,
+    );
+    expect(outputDirDeclaration, "outputDir must be declared as path.join(..., \"content\")").not.toBeNull();
+
+    const { named, aliases } = fsBindingsOf(text);
+    const writeNames = WRITE_OR_DELETE_FNS.filter((n) => named.has(n));
+    const calls = callsOf(text, writeNames, [...aliases]);
+    expect(calls.length).toBeGreaterThan(0);
+
+    for (const rawArgs of calls) {
+      const target = firstArgument(rawArgs);
+      const targetsContent = target === "outputDir" || target.startsWith("path.join(outputDir");
+      expect(targetsContent, `write/delete target "${target}" must be outputDir or path.join(outputDir, ...)`).toBe(true);
+    }
+  });
+});
+
+describe("nothing reads content/ (CP3)", () => {
+  it("has no file under src/ or scripts/ that reads a file under content/", () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      const fileDir = path.dirname(file);
+      const { named, aliases } = fsBindingsOf(text);
+      const readNames = READ_FILE_FNS.filter((n) => named.has(n));
+      const calls = callsOf(text, readNames, [...aliases]);
+      for (const rawArgs of calls) {
+        const target = firstArgument(rawArgs);
+        // A string literal argument is resolved directly; anything dynamic that even
+        // mentions the content directory's name is flagged rather than silently passed.
+        const literal = target.match(/^["'](.+)["']$/);
+        const resolved = literal ? path.resolve(fileDir, literal[1]!) : null;
+        if ((resolved && isInside(resolved, contentDir)) || /\bcontentDir\b|\boutputDir\b/.test(target)) {
+          violations.push(`${relativePosix(file)} reads "${target}"`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
**What changed, and why.** Adds a single test file, `src/published-surface.test.ts`, that
statically enumerates every `.ts`/`.mjs` file under `src/` and `scripts/` and enforces CP1
(no import reaches past the engine's published surface or escapes this repository's own
sources), CP2 (the exporter is the only writer/deleter under `content/`, and every write or
delete it performs resolves under `content/`), and CP3 (nothing reads a file under
`content/`). The engine submodule puts its own source tree a short relative import away, so
CP1 in particular fails silently today — this catches it in seconds instead of at the next
pin move. Fills the CP1–CP3 `Evidence` cells in `design/20-contract.md` with the test's path,
per the contract's own rule that a `Code` row's `Evidence` cell must name what enforces it.

Closes #80

### Verified

Ran and passed:
- Parse-check PowerShell scripts — Get-ChildItem -Path . -Recurse -Filter *.ps1 | [System.Management.Automation.Language.Parser]::ParseFile per file. 99 files checked, all parsed cleanly, no syntax errors.
- Run Pester tests — Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 312.21s (UserDuration 00:04:45.07).
- Validate the core/companion split — Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid. Findings: none. Exit code: 0.
- Check the design state against the tree — State: Valid (exit 0). Findings (blocking): 0. Reported (non-blocking): 26, all class MirrorStale on work/8 through work/91, each because MirroredAt still names an earlier commit rather than this branch's own commit a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c, expected on an unmerged feature branch, not a design freeze or a downgrade (DowngradedCount: 0). CouldNotEvaluate: 0. Largest closure: unit/document/design-20-contract, 8601 bytes (ceiling 16384).
- Check the spec set — Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 0 findings; 0 unchecked; 8 references unresolvable (cross-repository, engine/*.md in SubZeroDev.GameEngine, not checked from this repository). Commit: a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c. WorkingTree: Dirty at the time this gate ran (only .claude/gates.json, refreshed by this same verify pass for the new content-path gates below; no source file was uncommitted). Exit code: 0.
- Build the pinned engine — npm run setup (npm --prefix engine/src/engine ci && npm --prefix engine/src/engine run build) — exit 0. Installed 140 packages in 6s (npm audit reported 1 pre-existing high-severity advisory in the engine submodule's own dependency tree, unrelated to this change and not part of this gate). Engine built via `npm run clean && tsc -p tsconfig.build.json` with no errors.
- Typecheck the campaign sources — npm run typecheck (tsc --noEmit) — exit 0, no type errors.
- Test the campaign sources — npm test (vitest run) — Test Files 2 passed (2), Tests 11 passed (11), Duration 2.88s. Includes the new src/published-surface.test.ts (4 tests: CP1, CP2 x2, CP3) alongside the existing src/campaigns/stable-life.test.ts (7 tests).
- Re-export content and fail if the committed JSON is stale — npm run export:content && npm run check:clean — exit 0. export-content.ts: "Exported 1 campaign(s) to content/". check-clean.mjs: "content/ matches the sources." — this slice touches no campaign source, so the committed content/ was already current.
- git diff --check — git diff --check exited 0 — no trailing whitespace or conflict markers on this branch's changes.

Ran and failed: none.

Did not run:
- docs.ps1 -BuildOnly (Docusaurus image build) — Not CI-gated (no `# verification: true` flag on any docs.ps1-related step in .github/workflows/*.yml). This change touches no docs/ files, so the build was not run rather than spending an unrelated Docker build cycle on it.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Slice:** S12 — `design/30-slices.md` § S12 @ `1ec3337099d3ad2b763987c14cef6cdd67e2b05a`
- **Criteria met:** S12.1, S12.2, S12.3, S12.4, S12.5, S12.6
- **Left undone:** none
<!-- agent:end -->
</details>
