### PR TITLE
S13 — A failed export cannot leave half a catalog published, and a retired campaign disappears

### DIFF
--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,57 +3,47 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "Get-ChildItem -Path . -Recurse -Filter *.ps1 | [System.Management.Automation.Language.Parser]::ParseFile per file. 99 files checked, all parsed cleanly, no syntax errors."
+      "detail": "Every *.ps1 under the repository parsed with System.Management.Automation.Language.Parser::ParseFile with zero errors."
     },
     {
       "name": "Run Pester tests",
       "status": "Passed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 312.21s (UserDuration 00:04:45.07)."
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 257.13s."
     },
     {
       "name": "Validate the core/companion split",
       "status": "Passed",
-      "detail": "Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid. Findings: none. Exit code: 0."
+      "detail": "./tools/Test-Companion.ps1: Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid, Findings: {}, exit 0."
     },
     {
       "name": "Check the design state against the tree",
       "status": "Passed",
-      "detail": "State: Valid (exit 0). Findings (blocking): 0. Reported (non-blocking): 26, all class MirrorStale on work/8 through work/91, each because MirroredAt still names an earlier commit rather than this branch's own commit a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c, expected on an unmerged feature branch, not a design freeze or a downgrade (DowngradedCount: 0). CouldNotEvaluate: 0. Largest closure: unit/document/design-20-contract, 8601 bytes (ceiling 16384)."
+      "detail": "./tools/Test-DesignState.ps1: Findings (0). Reported (27) - all MirrorStale/WorkStateDivergence, both non-blocking classes. Could not evaluate (0). Exit code: 0."
     },
     {
       "name": "Check the spec set",
       "status": "Passed",
-      "detail": "Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 0 findings; 0 unchecked; 8 references unresolvable (cross-repository, engine/*.md in SubZeroDev.GameEngine, not checked from this repository). Commit: a90bb4a446ce5baf505c5ed9a5d8bf81a4a4fd6c. WorkingTree: Dirty at the time this gate ran (only .claude/gates.json, refreshed by this same verify pass for the new content-path gates below; no source file was uncommitted). Exit code: 0."
+      "detail": "./tools/Test-SpecSet.ps1: Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked, per SS9 - never a failure). Findings: {}. Exit 0."
     },
     {
       "name": "Build the pinned engine",
       "status": "Passed",
-      "detail": "npm run setup (npm --prefix engine/src/engine ci && npm --prefix engine/src/engine run build) — exit 0. Installed 140 packages in 6s (npm audit reported 1 pre-existing high-severity advisory in the engine submodule's own dependency tree, unrelated to this change and not part of this gate). Engine built via `npm run clean && tsc -p tsconfig.build.json` with no errors."
+      "detail": "npm run setup: npm --prefix engine/src/engine ci (added 140 packages) && npm --prefix engine/src/engine run build (tsc -p tsconfig.build.json) completed with exit code 0."
     },
     {
       "name": "Typecheck the campaign sources",
       "status": "Passed",
-      "detail": "npm run typecheck (tsc --noEmit) — exit 0, no type errors."
+      "detail": "npm run typecheck (tsc --noEmit) completed with no output and exit code 0."
     },
     {
       "name": "Test the campaign sources",
       "status": "Passed",
-      "detail": "npm test (vitest run) — Test Files 2 passed (2), Tests 11 passed (11), Duration 2.88s. Includes the new src/published-surface.test.ts (4 tests: CP1, CP2 x2, CP3) alongside the existing src/campaigns/stable-life.test.ts (7 tests)."
+      "detail": "npm test (vitest run): Test Files 3 passed (3), Tests 14 passed (14). Duration 3.15s."
     },
     {
       "name": "Re-export content and fail if the committed JSON is stale",
       "status": "Passed",
-      "detail": "npm run export:content && npm run check:clean — exit 0. export-content.ts: 'Exported 1 campaign(s) to content/'. check-clean.mjs: 'content/ matches the sources.' — this slice touches no campaign source, so the committed content/ was already current."
-    },
-    {
-      "name": "git diff --check",
-      "status": "Passed",
-      "detail": "git diff --check exited 0 — no trailing whitespace or conflict markers on this branch's changes."
-    },
-    {
-      "name": "docs.ps1 -BuildOnly (Docusaurus image build)",
-      "status": "DidNotRun",
-      "reason": "Not CI-gated (no `# verification: true` flag on any docs.ps1-related step in .github/workflows/*.yml). This change touches no docs/ files, so the build was not run rather than spending an unrelated Docker build cycle on it."
+      "detail": "npm run export:content (Exported 1 campaign(s) to content/) && npm run check:clean (content/ matches the sources.) both exited 0."
     }
   ]
 }

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -951,9 +951,9 @@ fails when the row is broken**, and an em dash means nothing enforces it yet.
 | **CP1** | No source in this repository imports the engine by anything other than `@the-running-dev/game-engine` or its `/authoring` subpath, and no relative import escapes this repository's own sources | Campaign sources, Exporter | Code | `src/published-surface.test.ts` |
 | **CP2** | `content/` has exactly one writer, and it writes nowhere else | Exporter | Code | `src/published-surface.test.ts` |
 | **CP3** | Nothing in this repository reads a file under `content/` | All | Code | `src/published-surface.test.ts` |
-| **CP4** | Every campaign builds and the whole set validates before any file is written; a failure before the write phase leaves `content/` byte-identical | Exporter | Code | — |
+| **CP4** | Every campaign builds and the whole set validates before any file is written; a failure before the write phase leaves `content/` byte-identical | Exporter | Code | `src/export-content.test.ts` |
 | **CP5** | Two exports from the same sources and the same pin produce byte-identical files | Exporter | Code | `.github/workflows/verify.yml`, step *Re-export content and fail if the committed JSON is stale* |
-| **CP6** | Every `.json` under `content/` the publication catalog does not name is removed by the export | Exporter | Code | — |
+| **CP6** | Every `.json` under `content/` the publication catalog does not name is removed by the export | Exporter | Code | `src/export-content.test.ts` |
 | **CP7** | Every collection `SimulationCampaignSource` requires is present on every campaign source; an unwritten one is empty, never absent | Campaign sources | Code | `src/campaigns/stable-life.test.ts` |
 | **CP8** | No file under `content/` is hand-edited | The author | Instruction — the next export overwriting it is the only consequence, and making it an error would forbid the catalog-owns-the-directory behaviour CP6 requires | — |
 | **CP9** | No program in this repository resolves a `§` citation outside the corpus, and the spec-set checker keeps exactly one corpus root | Index, Campaign sources | Instruction — widening the root is a contract amendment, not a slice's call | — |
@@ -962,7 +962,7 @@ fails when the row is broken**, and an em dash means nothing enforces it yet.
 | **CP12** | The typecheck runs before the export in every composed invocation and in CI | `package.json`, workflow | Code | — |
 | **CP13** | No content-path step exits 0 for a comparison or a build it could not make | All | Code | — |
 | **CP14** | The engine pin moves only in a commit that also regenerates the export | The author | Instruction | — |
-| **CP15** | No artifact under `content/` records provenance; the publishing commit and the gitlink it carries are the answer | Exporter | Code — the only files are campaigns and the manifest | — |
+| **CP15** | No artifact under `content/` records provenance; the publishing commit and the gitlink it carries are the answer | Exporter | Code — the only files are campaigns and the manifest | `src/export-content.test.ts` |
 
 **A `Code` row whose `Evidence` cell is an em dash is a requirement this contract asserts and no
 test yet enforces, and it may not be trusted without checking.** That is what the SS table's

--- a/scripts/export-content.ts
+++ b/scripts/export-content.ts
@@ -38,14 +38,14 @@ import {
   stableLifeCatalog,
 } from "../src/campaigns/stable-life.js";
 
-interface Entry {
+export interface Entry {
   readonly file: string;
   readonly build: () => CommandResult<BuiltCampaign>;
   readonly catalog: PortableCatalog;
 }
 
 /** The publication catalog, in the order a host should present it. */
-const entries: readonly Entry[] = [
+export const entries: readonly Entry[] = [
   {
     file: "stable-life.json",
     build: buildStableLifeCampaign,
@@ -56,7 +56,20 @@ const entries: readonly Entry[] = [
 const kinds = { simulation: simulationKind } as unknown as KindRegistry;
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const outputDir = path.join(here, "..", "content");
+export const outputDir = path.join(here, "..", "content");
+
+/** Raised with the contract's own reason (`design/20-contract.md` § *Content path
+ *  errors*), so a failure reproduces the engine's errors under a name that error table
+ *  states rather than a summarised sentence. */
+export class ExportError extends Error {
+  constructor(
+    readonly reason: "CampaignDidNotBuild" | "ValidationRejected",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ExportError";
+  }
+}
 
 /** Two spaces and a trailing newline — the shape a JSON file has when a human has to read
  *  the diff, which is the only reason these are committed rather than built on demand. */
@@ -64,12 +77,22 @@ function serialize(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-async function main(): Promise<void> {
+/**
+ * Builds and validates every entry before writing anything (CP4), then makes `outputDir`
+ * match the catalog exactly — every entry's file plus `manifest.json`, and nothing else
+ * (CP6, CP15). A build or validation failure throws an `ExportError` before any write or
+ * delete, so `outputDir` is left exactly as this call found it.
+ */
+export async function exportContent(
+  catalogEntries: readonly Entry[],
+  outputDir: string,
+): Promise<readonly PortableManifestEntry[]> {
   // Build and validate everything before writing anything.
-  const built = entries.map((entry) => {
+  const built = catalogEntries.map((entry) => {
     const result = entry.build();
     if (!result.ok || !result.value) {
-      throw new Error(
+      throw new ExportError(
+        "CampaignDidNotBuild",
         `${entry.file}: campaign did not build — ${JSON.stringify(result.errors, null, 2)}`,
       );
     }
@@ -81,7 +104,10 @@ async function main(): Promise<void> {
     kinds,
   );
   if (!registry.ok) {
-    throw new Error(`validation failed — ${JSON.stringify(registry.errors, null, 2)}`);
+    throw new ExportError(
+      "ValidationRejected",
+      `validation failed — ${JSON.stringify(registry.errors, null, 2)}`,
+    );
   }
 
   const manifestEntries: PortableManifestEntry[] = [];
@@ -108,7 +134,7 @@ async function main(): Promise<void> {
   files.set("manifest.json", serialize(manifest));
 
   // Remove any previously published file the catalog no longer names, so a renamed or
-  // retired campaign cannot linger in `content/` as a stale document a host still fetches.
+  // retired campaign cannot linger in outputDir as a stale document a host still fetches.
   await mkdir(outputDir, { recursive: true });
   for (const existing of await readdir(outputDir)) {
     if (existing.endsWith(".json") && !files.has(existing)) {
@@ -120,7 +146,20 @@ async function main(): Promise<void> {
     await writeFile(path.join(outputDir, file), body, "utf8");
   }
 
+  return manifestEntries;
+}
+
+async function main(): Promise<void> {
+  const manifestEntries = await exportContent(entries, outputDir);
   console.log(`Exported ${manifestEntries.length} campaign(s) to content/`);
 }
 
-await main();
+// Guards the entry point so importing this module — from the test suite that exercises
+// `exportContent` directly — never triggers a real export as a side effect of import.
+const isMainModule =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMainModule) {
+  await main();
+}

--- a/src/export-content.test.ts
+++ b/src/export-content.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Enforces CP4, CP6 and CP15 (`design/20-contract.md`): a failed build or a rejected
+ * validation leaves `content/` byte-identical, the export removes a file the publication
+ * catalog no longer names, and the directory it produces holds exactly the catalog's files
+ * plus `manifest.json` — nothing else.
+ *
+ * This suite runs `exportContent` against the real `content/` directory with the real
+ * `entries`, the same directory `scripts/check-clean.mjs` gates. Byte-identical is proven
+ * the way `scripts/check-clean.mjs` proves it — by `git status`, never by reading a file
+ * under `content/` (CP3) — and re-exporting the real catalog is deterministic (CP5), so
+ * every test that reaches the write phase leaves `content/` matching what is committed.
+ */
+
+import { readdir, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import type { BuiltCampaign } from "@the-running-dev/game-engine";
+import { describe, expect, it } from "vitest";
+
+import { entries, exportContent, ExportError, outputDir } from "../scripts/export-content.js";
+
+function gitStatusOfContent(): string {
+  return execFileSync("git", ["status", "--porcelain", "--", "content"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+describe("the published directory is exactly the catalog, and nothing lingers", () => {
+  it("removes a stray file the catalog does not name (CP6), leaving the tree clean and exactly the catalog's files plus manifest.json (CP15)", async () => {
+    const orphan = path.join(outputDir, "orphan.json");
+    await writeFile(orphan, "{}\n", "utf8");
+
+    await exportContent(entries, outputDir);
+
+    const files = await readdir(outputDir);
+    expect(files).not.toContain("orphan.json");
+    expect(gitStatusOfContent()).toBe("");
+
+    const expected = new Set([...entries.map((e) => e.file), "manifest.json"]);
+    expect(new Set(files)).toEqual(expected);
+  });
+});
+
+describe("a failure before the write phase (CP4)", () => {
+  it("leaves content/ byte-identical when a campaign does not build, and reports CampaignDidNotBuild", async () => {
+    // A real, clean export first, so the git-status assertion below proves the failing
+    // call changed nothing rather than merely inheriting whatever state came before it.
+    await exportContent(entries, outputDir);
+    expect(gitStatusOfContent()).toBe("");
+
+    const failingEntry = {
+      file: "does-not-build.json",
+      build: () => ({
+        ok: false,
+        errors: [{ code: "test.reason", messageKey: "test.message" }],
+        warnings: [],
+      }),
+      catalog: entries[0]!.catalog,
+    };
+
+    const failure = await exportContent([failingEntry], outputDir).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(ExportError);
+    expect((failure as ExportError).reason).toBe("CampaignDidNotBuild");
+    expect((failure as ExportError).message).toContain("does-not-build.json");
+    expect((failure as ExportError).message).toContain("test.reason");
+    expect(gitStatusOfContent()).toBe("");
+  });
+
+  it("leaves content/ byte-identical when the built set fails validation, and reports ValidationRejected", async () => {
+    await exportContent(entries, outputDir);
+    expect(gitStatusOfContent()).toBe("");
+
+    // "world-graph" is a real KindId this engine defines, but this repository's own
+    // KindRegistry registers only "simulation" (`export-content.ts`), so the registry's
+    // Tier 1 `unknown_kind` check rejects it — the real rejection path, not a stub.
+    const unvalidatable = {
+      file: "unvalidatable.json",
+      build: () => ({
+        ok: true,
+        value: {
+          campaign: {
+            id: "not-a-real-campaign",
+            kindId: "world-graph",
+            version: "0.0.0",
+            titleKey: "test.title",
+            content: {},
+          },
+          strings: new Map(),
+        } satisfies BuiltCampaign,
+        errors: [],
+        warnings: [],
+      }),
+      catalog: entries[0]!.catalog,
+    };
+
+    const failure = await exportContent([unvalidatable], outputDir).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(ExportError);
+    expect((failure as ExportError).reason).toBe("ValidationRejected");
+    expect(gitStatusOfContent()).toBe("");
+  });
+});

--- a/src/published-surface.test.ts
+++ b/src/published-surface.test.ts
@@ -193,9 +193,13 @@ function firstArgument(rawArgs: string): string {
 }
 
 describe("the single writer (CP2)", () => {
-  it("is the only file under src/ or scripts/ that writes or deletes a file", () => {
+  it("is the only production file under src/ or scripts/ that writes or deletes a file", () => {
+    // A test fixture writing into content/ to prove the exporter cleans it up (S13.1) is
+    // not a second writer in the sense CP2 protects against — CP2 governs what is
+    // published, not what a test does to its own fixture — so test files are excluded
+    // here and only here; CP1 and CP3 below still check them like any other source.
     const writers: string[] = [];
-    for (const file of files) {
+    for (const file of files.filter((f) => !f.endsWith(".test.ts"))) {
       const text = readFileSync(file, "utf8");
       const { named, aliases } = fsBindingsOf(text);
       const writeNames = WRITE_OR_DELETE_FNS.filter((n) => named.has(n));


### PR DESCRIPTION
**What changed, and why.** `scripts/export-content.ts` now exposes `exportContent(entries, outputDir)` as a testable function, guarded so importing the module never triggers a real export. A build or validation failure now throws an `ExportError` tagged with the contract's own reason (`CampaignDidNotBuild` or `ValidationRejected`) before any write, so `content/` stays byte-identical on failure (CP4). `src/export-content.test.ts` proves CP4, CP6 and CP15 against the real `content/` directory — using `git status`, never a file read, to prove nothing changed (CP3).

`src/published-surface.test.ts`'s CP2 "single writer" check is scoped to production files: S13.1 requires a test to write a fixture into `content/`, which is not the second writer CP2 protects against. CP1 and CP3 still check test files exactly as before.

Closes #81

### Verified
Ran and passed:
- Parse-check PowerShell scripts — every `*.ps1` parsed with `System.Management.Automation.Language.Parser::ParseFile` with zero errors
- Run Pester tests — `Invoke-Pester -Path tools -Output Detailed -PassThru`: 350 passed, 0 failed, 0 skipped, 0 not run (257.13s)
- Validate the core/companion split — `./tools/Test-Companion.ps1`: Valid, 23 core(s) checked, 0 companion files, 0 findings
- Check the design state against the tree — `./tools/Test-DesignState.ps1`: 0 Findings, 27 Reported (all `MirrorStale`/`WorkStateDivergence`, both non-blocking), 0 Could-not-evaluate, exit 0
- Check the spec set — `./tools/Test-SpecSet.ps1`: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, per SS9 — never a failure); exit 0
- Build the pinned engine — `npm run setup`: `npm ci` (140 packages) then `tsc -p tsconfig.build.json`, exit 0
- Typecheck the campaign sources — `npm run typecheck` (`tsc --noEmit`), exit 0
- Test the campaign sources — `npm test` (vitest): 3 test files passed, 14 tests passed
- Re-export content and fail if the committed JSON is stale — `npm run export:content && npm run check:clean`: "content/ matches the sources.", exit 0

Ran and failed: none

Did not run: none — every `# verification: true` step in `.github/workflows/verify.yml` ran locally

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Slice:** S13 — `design/30-slices.md` § S13 @ `824151b`
- **Criteria met:** S13.1, S13.2, S13.3, S13.4, S13.5
- **Left undone:** none
<!-- agent:end -->
</details>