### PR TITLE
S14 — The content gate cannot be relaxed, reordered, or made to pass without running

### DIFF
--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,47 +3,47 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "Every *.ps1 under the repository parsed with System.Management.Automation.Language.Parser::ParseFile with zero errors."
+      "detail": "All *.ps1 files parsed with System.Management.Automation.Language.Parser, zero parse errors."
     },
     {
       "name": "Run Pester tests",
       "status": "Passed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0. Tests completed in 257.13s."
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 319.86s. Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0."
     },
     {
       "name": "Validate the core/companion split",
       "status": "Passed",
-      "detail": "./tools/Test-Companion.ps1: Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid, Findings: {}, exit 0."
+      "detail": "Companion split OK - 23 core(s) checked, 0 companion file(s) present, 23 core(s) with no companion. State: Valid, Findings: {}, exit 0."
     },
     {
       "name": "Check the design state against the tree",
       "status": "Passed",
-      "detail": "./tools/Test-DesignState.ps1: Findings (0). Reported (27) - all MirrorStale/WorkStateDivergence, both non-blocking classes. Could not evaluate (0). Exit code: 0."
+      "detail": "Findings (0). Reported (26): all MirrorStale on design/state/work/*.md, non-blocking by contract (design/20-contract.md § The divergence classes) because this branch has not yet run /track to refresh the mirror against its new commits. Could not evaluate (0). Exit code: 0."
     },
     {
       "name": "Check the spec set",
       "status": "Passed",
-      "detail": "./tools/Test-SpecSet.ps1: Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked, per SS9 - never a failure). Findings: {}. Exit 0."
+      "detail": "Spec-set: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked). State: Valid, Findings: {}, WorkingTree: Clean, exit 0."
     },
     {
       "name": "Build the pinned engine",
       "status": "Passed",
-      "detail": "npm run setup: npm --prefix engine/src/engine ci (added 140 packages) && npm --prefix engine/src/engine run build (tsc -p tsconfig.build.json) completed with exit code 0."
+      "detail": "npm run setup: npm --prefix engine/src/engine ci (added 140 packages) && npm run build (clean + tsc -p tsconfig.build.json) completed with exit 0."
     },
     {
       "name": "Typecheck the campaign sources",
       "status": "Passed",
-      "detail": "npm run typecheck (tsc --noEmit) completed with no output and exit code 0."
+      "detail": "npm run typecheck: tsc --noEmit completed with no output and exit 0."
     },
     {
       "name": "Test the campaign sources",
       "status": "Passed",
-      "detail": "npm test (vitest run): Test Files 3 passed (3), Tests 14 passed (14). Duration 3.15s."
+      "detail": "npm test: vitest run - Test Files 4 passed (4), Tests 19 passed (19), exit 0. Includes the 5 new tests in src/check-clean.test.ts covering CP11/CP12/CP13."
     },
     {
       "name": "Re-export content and fail if the committed JSON is stale",
       "status": "Passed",
-      "detail": "npm run export:content (Exported 1 campaign(s) to content/) && npm run check:clean (content/ matches the sources.) both exited 0."
+      "detail": "npm run export:content: 'Exported 1 campaign(s) to content/', exit 0. npm run check:clean: 'content/ matches the sources.', exit 0. git status --short reported nothing under content/ after the run."
     }
   ]
 }

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -958,9 +958,9 @@ fails when the row is broken**, and an em dash means nothing enforces it yet.
 | **CP8** | No file under `content/` is hand-edited | The author | Instruction — the next export overwriting it is the only consequence, and making it an error would forbid the catalog-owns-the-directory behaviour CP6 requires | — |
 | **CP9** | No program in this repository resolves a `§` citation outside the corpus, and the spec-set checker keeps exactly one corpus root | Index, Campaign sources | Instruction — widening the root is a contract amendment, not a slice's call | — |
 | **CP10** | Where the pinned engine cannot express a requirement the corpus states, the campaign omits it visibly and names the omission, and the gap is raised in the engine repository rather than worked around here | Campaign sources | Instruction — the brief's non-goal is the enforcement available | — |
-| **CP11** | The clean check compares only `content/`, and no parameter widens or relaxes the comparison | Clean check | Code | — |
-| **CP12** | The typecheck runs before the export in every composed invocation and in CI | `package.json`, workflow | Code | — |
-| **CP13** | No content-path step exits 0 for a comparison or a build it could not make | All | Code | — |
+| **CP11** | The clean check compares only `content/`, and no parameter widens or relaxes the comparison | Clean check | Code | `src/check-clean.test.ts` |
+| **CP12** | The typecheck runs before the export in every composed invocation and in CI | `package.json`, workflow | Code | `src/check-clean.test.ts` |
+| **CP13** | No content-path step exits 0 for a comparison or a build it could not make | All | Code | `src/check-clean.test.ts` |
 | **CP14** | The engine pin moves only in a commit that also regenerates the export | The author | Instruction | — |
 | **CP15** | No artifact under `content/` records provenance; the publishing commit and the gitlink it carries are the answer | Exporter | Code — the only files are campaigns and the manifest | `src/export-content.test.ts` |
 

--- a/scripts/check-clean.mjs
+++ b/scripts/check-clean.mjs
@@ -7,18 +7,35 @@
  * because both the source and the output look internally consistent.
  *
  * Scoped to `content/` on purpose: an unrelated dirty working tree is the author's own
- * business and is not this gate's to fail on.
+ * business and is not this gate's to fail on (CP11).
+ *
+ * Reports the contract's own reasons (`design/20-contract.md` § *Content path errors*):
+ * `ExportStale` when the export differs from what is committed, `GitUnavailable` when git
+ * cannot be invoked or this is not a checkout. Never exits 0 for a comparison it could not
+ * make (CP13).
  */
 
 import { execFileSync } from "node:child_process";
 
-const status = execFileSync("git", ["status", "--porcelain", "--", "content"], {
-  encoding: "utf8",
-});
+let status;
+try {
+  status = execFileSync("git", ["status", "--porcelain", "--", "content"], {
+    encoding: "utf8",
+  });
+} catch (error) {
+  console.error("GitUnavailable: git is absent, or this working directory is not a checkout.");
+  console.error(error.message);
+  process.exit(1);
+}
 
 if (status.trim() !== "") {
-  console.error("content/ is out of date with src/campaigns/. Re-run `npm run export:content` and commit the result.\n");
-  console.error(status);
+  const differing = status
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => line.replace(/^..\s+/, "  "));
+
+  console.error("ExportStale: content/ is out of date with src/campaigns/. Re-run `npm run export:content` and commit the result.\n");
+  console.error(differing.join("\n"));
   process.exit(1);
 }
 

--- a/src/check-clean.test.ts
+++ b/src/check-clean.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Enforces CP11, CP12 and CP13 (`design/20-contract.md`): the clean check compares only
+ * `content/`, the typecheck runs before the export in every composed invocation and in CI,
+ * and no content-path step exits 0 for a comparison it could not make.
+ *
+ * The clean check is run as the real subprocess `scripts/check-clean.mjs` gates on — a
+ * black-box test proves what a reviewer trusting the gate actually gets, not what an
+ * internal function happens to return.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, "..");
+const checkCleanScript = path.join(projectRoot, "scripts", "check-clean.mjs");
+
+function gitStatusOfContent(): string {
+  return execFileSync("git", ["status", "--porcelain", "--", "content"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+  }).trim();
+}
+
+interface RunResult {
+  readonly status: number;
+  readonly output: string;
+}
+
+function runCheckClean(cwd: string): RunResult {
+  try {
+    const output = execFileSync("node", [checkCleanScript], { cwd, encoding: "utf8" });
+    return { status: 0, output };
+  } catch (error) {
+    const e = error as { status: number | null; stdout: string; stderr: string };
+    return { status: e.status ?? 1, output: `${e.stdout}${e.stderr}` };
+  }
+}
+
+describe("the clean check is scoped to content/ (CP11)", () => {
+  it("exits 0 for a change outside content/", async () => {
+    const scratch = path.join(projectRoot, "check-clean-scratch.tmp");
+    await writeFile(scratch, "outside content/\n", "utf8");
+    try {
+      const result = runCheckClean(projectRoot);
+      expect(result.status).toBe(0);
+    } finally {
+      await rm(scratch);
+    }
+  });
+
+  it("exits non-zero and reports ExportStale, naming the differing file, for a change under content/", async () => {
+    expect(gitStatusOfContent()).toBe("");
+
+    const manifestPath = path.join(projectRoot, "content", "manifest.json");
+    const original = await readFile(manifestPath, "utf8");
+    await writeFile(manifestPath, `${original}\n`, "utf8");
+    try {
+      const result = runCheckClean(projectRoot);
+      expect(result.status).not.toBe(0);
+      expect(result.output).toContain("ExportStale");
+      expect(result.output).toContain("content/manifest.json");
+    } finally {
+      await writeFile(manifestPath, original, "utf8");
+      expect(gitStatusOfContent()).toBe("");
+    }
+  });
+});
+
+describe("no content-path step exits 0 for a comparison it could not make (CP13)", () => {
+  it("reports GitUnavailable and exits non-zero when the working directory is not a checkout", async () => {
+    const notACheckout = await mkdtemp(path.join(os.tmpdir(), "check-clean-not-a-checkout-"));
+    try {
+      const result = runCheckClean(notACheckout);
+      expect(result.status).not.toBe(0);
+      expect(result.output).toContain("GitUnavailable");
+    } finally {
+      await rm(notACheckout, { recursive: true });
+    }
+  });
+});
+
+describe("the export runs before the clean check, and the typecheck before both (CP12)", () => {
+  it("orders typecheck, export:content and check:clean in package.json's composed check script", async () => {
+    const pkg = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    const check = pkg.scripts.check ?? "";
+    const typecheckAt = check.indexOf("typecheck");
+    const exportAt = check.indexOf("export:content");
+    const checkCleanAt = check.indexOf("check:clean");
+
+    expect(typecheckAt).toBeGreaterThanOrEqual(0);
+    expect(exportAt).toBeGreaterThan(typecheckAt);
+    expect(checkCleanAt).toBeGreaterThan(exportAt);
+  });
+
+  it("orders the content job's typecheck step before the re-export step, sets submodules: recursive, and sets continue-on-error nowhere", async () => {
+    const workflow = await readFile(
+      path.join(projectRoot, ".github", "workflows", "verify.yml"),
+      "utf8",
+    );
+
+    const contentJobAt = workflow.indexOf("\n  content:\n");
+    expect(contentJobAt).toBeGreaterThanOrEqual(0);
+    const contentJob = workflow.slice(contentJobAt);
+
+    const typecheckStepAt = contentJob.indexOf("Typecheck the campaign sources");
+    const reExportStepAt = contentJob.indexOf(
+      "Re-export content and fail if the committed JSON is stale",
+    );
+    expect(typecheckStepAt).toBeGreaterThanOrEqual(0);
+    expect(reExportStepAt).toBeGreaterThan(typecheckStepAt);
+
+    expect(contentJob).toContain("submodules: recursive");
+    expect(contentJob).not.toContain("continue-on-error");
+  });
+});


### PR DESCRIPTION
`scripts/check-clean.mjs` used to crash uncaught when git failed and never named what
differed when it succeeded but found staleness. It now reports the contract's own reasons —
`ExportStale` naming the differing file, `GitUnavailable` when git cannot be invoked or the
directory is not a checkout — and never exits 0 for a comparison it could not make.
`src/check-clean.test.ts` proves all three (CP11, CP12, CP13) as a black-box test against the
real subprocess the gate runs, rather than an internal function.

Closes #82

### Verified

Ran and passed:
- Parse-check PowerShell scripts — All `*.ps1` files parsed with `System.Management.Automation.Language.Parser`, zero parse errors.
- Run Pester tests — `Invoke-Pester -Path tools`: Tests completed in 319.86s. Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0.
- Validate the core/companion split — `./tools/Test-Companion.ps1`: 23 core(s) checked, 0 companion file(s), State: Valid, Findings: {}, exit 0.
- Check the design state against the tree — `./tools/Test-DesignState.ps1`: Findings (0). Reported (26): all `MirrorStale` on `design/state/work/*.md`, non-blocking by contract (`design/20-contract.md` § *The divergence classes*) — this branch has not yet had `/track` refresh the mirror against its new commits. Could not evaluate (0). Exit code: 0.
- Check the spec set — `./tools/Test-SpecSet.ps1`: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked). WorkingTree: Clean, exit 0.
- Build the pinned engine — `npm run setup`: `npm --prefix engine/src/engine ci` (140 packages) and `npm run build` completed, exit 0.
- Typecheck the campaign sources — `npm run typecheck`: `tsc --noEmit`, no output, exit 0.
- Test the campaign sources — `npm test`: `vitest run` — 4 files passed, 19 tests passed, exit 0. Includes the 5 new tests in `src/check-clean.test.ts`.
- Re-export content and fail if the committed JSON is stale — `npm run export:content && npm run check:clean`: "Exported 1 campaign(s) to content/", then "content/ matches the sources.", both exit 0. `git status --short` reported nothing under `content/` afterward.

Ran and failed: none.

Did not run: none — every `# verification: true` step in `.github/workflows/verify.yml` ran locally.

---
<details><summary><b>Agent detail</b></summary>
<!-- agent:start -->

- **Slice:** S14 — `design/30-slices.md` § S14 @ `1ec3337099d3ad2b763987c14cef6cdd67e2b05a`
- **Criteria met:** S14.1, S14.2, S14.3, S14.4, S14.5, S14.6
- **Left undone:** none
<!-- agent:end -->
</details>
