### PR TITLE
S15 — There is work to take, and a way up from it

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -5,7 +5,7 @@
       "file": "stable-life.json",
       "id": "life-in-the-fast-lane-stable-life",
       "version": "0.1.0",
-      "digest": "sha-256:b99933dc3d95ea8d52c0b45b506db0931c68900b354b79914d323745d54b1b07"
+      "digest": "sha-256:29e6dcfdc8aa16b609a6174269b4040edcf20bb6c31f1975836578e49e127a3e"
     }
   ],
   "resolution": "sha-256:69d83e73ed1b957f9f09ff86d146b21f928b91748108f76b806f403b0ae112d4"

--- a/content/stable-life.json
+++ b/content/stable-life.json
@@ -4,7 +4,7 @@
     "title": "Life in the Fast Lane — Stable Life",
     "description": "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
     "duration": "52 weeks",
-    "contentNotice": "Seed content. The map and the scenario are authored; jobs, courses, events and possessions are not yet written.",
+    "contentNotice": "Seed content. The map, the scenario and the career ladder are authored; courses, events and possessions are not yet written.",
     "featured": false,
     "hidden": true
   },
@@ -15,7 +15,338 @@
     "kindId": "simulation",
     "content": {
       "descriptionKey": "stable-life.campaign.description",
-      "jobs": [],
+      "jobs": [
+        {
+          "id": "job-dishwasher",
+          "employerId": "employer-greasy-spoon-diner",
+          "careerPathId": "career-food-service",
+          "tier": "entry",
+          "schedule": {
+            "weeklyTimeCost": 10,
+            "flexibility": 10
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 21000
+          },
+          "requirements": [],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [
+            {
+              "toJobId": "job-line-cook",
+              "minimumWeeksInRole": 8,
+              "minimumPerformance": 40,
+              "requirements": [],
+              "contested": false,
+              "baseChance": 85
+            }
+          ],
+          "terminationRules": [],
+          "contested": false,
+          "tags": [
+            "career-food-service"
+          ],
+          "titleKey": "stable-life.job.dishwasher.title",
+          "descriptionKey": "stable-life.job.dishwasher.description"
+        },
+        {
+          "id": "job-line-cook",
+          "employerId": "employer-greasy-spoon-diner",
+          "careerPathId": "career-food-service",
+          "tier": "skilled",
+          "schedule": {
+            "weeklyTimeCost": 9,
+            "flexibility": 20
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 34000
+          },
+          "requirements": [
+            {
+              "type": "skill",
+              "condition": {
+                "field": "player.skills.cooking",
+                "operator": "greater_or_equal",
+                "value": 25
+              },
+              "failureCode": "requirement_unmet",
+              "messageKey": "stable-life.job.line-cook.requirement.cooking"
+            }
+          ],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [
+            {
+              "toJobId": "job-shift-supervisor",
+              "minimumWeeksInRole": 12,
+              "minimumPerformance": 55,
+              "requirements": [
+                {
+                  "type": "skill",
+                  "condition": {
+                    "field": "player.skills.management",
+                    "operator": "greater_or_equal",
+                    "value": 40
+                  },
+                  "failureCode": "requirement_unmet",
+                  "messageKey": "stable-life.job.shift-supervisor.requirement.management"
+                }
+              ],
+              "contested": true,
+              "baseChance": 50
+            }
+          ],
+          "terminationRules": [],
+          "contested": false,
+          "tags": [
+            "career-food-service"
+          ],
+          "titleKey": "stable-life.job.line-cook.title",
+          "descriptionKey": "stable-life.job.line-cook.description"
+        },
+        {
+          "id": "job-shift-supervisor",
+          "employerId": "employer-greasy-spoon-diner",
+          "careerPathId": "career-food-service",
+          "tier": "professional",
+          "schedule": {
+            "weeklyTimeCost": 8,
+            "flexibility": 30
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 52000
+          },
+          "requirements": [
+            {
+              "type": "skill",
+              "condition": {
+                "field": "player.skills.management",
+                "operator": "greater_or_equal",
+                "value": 40
+              },
+              "failureCode": "requirement_unmet",
+              "messageKey": "stable-life.job.shift-supervisor.requirement.management"
+            }
+          ],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [],
+          "terminationRules": [],
+          "contested": true,
+          "positionsAvailable": 2,
+          "tags": [
+            "career-food-service"
+          ],
+          "titleKey": "stable-life.job.shift-supervisor.title",
+          "descriptionKey": "stable-life.job.shift-supervisor.description"
+        },
+        {
+          "id": "job-data-entry-clerk",
+          "employerId": "employer-civic-data-office",
+          "careerPathId": "career-clerical",
+          "tier": "entry",
+          "schedule": {
+            "weeklyTimeCost": 10,
+            "flexibility": 10
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 21000
+          },
+          "requirements": [],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [
+            {
+              "toJobId": "job-systems-administrator",
+              "minimumWeeksInRole": 8,
+              "minimumPerformance": 40,
+              "requirements": [],
+              "contested": false,
+              "baseChance": 85
+            }
+          ],
+          "terminationRules": [],
+          "contested": false,
+          "tags": [
+            "career-clerical"
+          ],
+          "titleKey": "stable-life.job.data-entry-clerk.title",
+          "descriptionKey": "stable-life.job.data-entry-clerk.description"
+        },
+        {
+          "id": "job-systems-administrator",
+          "employerId": "employer-civic-data-office",
+          "careerPathId": "career-clerical",
+          "tier": "skilled",
+          "schedule": {
+            "weeklyTimeCost": 9,
+            "flexibility": 25
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 34000
+          },
+          "requirements": [
+            {
+              "type": "skill",
+              "condition": {
+                "field": "player.skills.programming",
+                "operator": "greater_or_equal",
+                "value": 25
+              },
+              "failureCode": "requirement_unmet",
+              "messageKey": "stable-life.job.systems-administrator.requirement.programming"
+            }
+          ],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [
+            {
+              "toJobId": "job-infrastructure-engineer",
+              "minimumWeeksInRole": 12,
+              "minimumPerformance": 55,
+              "requirements": [
+                {
+                  "type": "skill",
+                  "condition": {
+                    "field": "player.skills.programming",
+                    "operator": "greater_or_equal",
+                    "value": 55
+                  },
+                  "failureCode": "requirement_unmet",
+                  "messageKey": "stable-life.job.infrastructure-engineer.requirement.programming"
+                }
+              ],
+              "contested": true,
+              "baseChance": 55
+            }
+          ],
+          "terminationRules": [],
+          "contested": false,
+          "tags": [
+            "career-clerical"
+          ],
+          "titleKey": "stable-life.job.systems-administrator.title",
+          "descriptionKey": "stable-life.job.systems-administrator.description"
+        },
+        {
+          "id": "job-infrastructure-engineer",
+          "employerId": "employer-civic-data-office",
+          "careerPathId": "career-clerical",
+          "tier": "professional",
+          "schedule": {
+            "weeklyTimeCost": 8,
+            "flexibility": 35
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 52000
+          },
+          "requirements": [
+            {
+              "type": "skill",
+              "condition": {
+                "field": "player.skills.programming",
+                "operator": "greater_or_equal",
+                "value": 55
+              },
+              "failureCode": "requirement_unmet",
+              "messageKey": "stable-life.job.infrastructure-engineer.requirement.programming"
+            }
+          ],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [
+            {
+              "toJobId": "job-wifi-scapegoat",
+              "minimumWeeksInRole": 16,
+              "minimumPerformance": 65,
+              "requirements": [],
+              "contested": true,
+              "baseChance": 35
+            }
+          ],
+          "terminationRules": [],
+          "contested": true,
+          "positionsAvailable": 2,
+          "tags": [
+            "career-clerical"
+          ],
+          "titleKey": "stable-life.job.infrastructure-engineer.title",
+          "descriptionKey": "stable-life.job.infrastructure-engineer.description"
+        },
+        {
+          "id": "job-wifi-scapegoat",
+          "employerId": "employer-civic-data-office",
+          "careerPathId": "career-clerical",
+          "tier": "senior",
+          "schedule": {
+            "weeklyTimeCost": 8,
+            "flexibility": 40
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 78000
+          },
+          "requirements": [],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [],
+          "terminationRules": [],
+          "contested": true,
+          "positionsAvailable": 1,
+          "tags": [
+            "career-clerical"
+          ],
+          "titleKey": "stable-life.job.wifi-scapegoat.title",
+          "descriptionKey": "stable-life.job.wifi-scapegoat.description"
+        },
+        {
+          "id": "job-retail-associate",
+          "employerId": "employer-bright-mart-retail",
+          "careerPathId": "career-retail",
+          "tier": "entry",
+          "schedule": {
+            "weeklyTimeCost": 10,
+            "flexibility": 15
+          },
+          "compensation": {
+            "baseWeeklyPayCents": 21000
+          },
+          "requirements": [],
+          "performance": {
+            "factors": [],
+            "weeklyDriftToward": 50,
+            "minimumAcceptable": 30
+          },
+          "promotionPaths": [],
+          "terminationRules": [],
+          "contested": false,
+          "tags": [
+            "career-retail"
+          ],
+          "titleKey": "stable-life.job.retail-associate.title",
+          "descriptionKey": "stable-life.job.retail-associate.description"
+        }
+      ],
       "courses": [],
       "housing": [
         {
@@ -127,7 +458,43 @@
       "opportunities": [],
       "achievements": [],
       "headlines": [],
-      "employers": [],
+      "employers": [
+        {
+          "id": "employer-greasy-spoon-diner",
+          "sector": "food-service",
+          "reputation": 40,
+          "jobIds": [
+            "job-dishwasher",
+            "job-line-cook",
+            "job-shift-supervisor"
+          ],
+          "npcIds": [],
+          "nameKey": "stable-life.employer.greasy-spoon-diner.name"
+        },
+        {
+          "id": "employer-civic-data-office",
+          "sector": "clerical",
+          "reputation": 55,
+          "jobIds": [
+            "job-data-entry-clerk",
+            "job-systems-administrator",
+            "job-infrastructure-engineer",
+            "job-wifi-scapegoat"
+          ],
+          "npcIds": [],
+          "nameKey": "stable-life.employer.civic-data-office.name"
+        },
+        {
+          "id": "employer-bright-mart-retail",
+          "sector": "retail",
+          "reputation": 50,
+          "jobIds": [
+            "job-retail-associate"
+          ],
+          "npcIds": [],
+          "nameKey": "stable-life.employer.bright-mart-retail.name"
+        }
+      ],
       "locations": [
         {
           "id": "home",
@@ -256,7 +623,26 @@
       ],
       "backgrounds": [],
       "traits": [],
-      "skills": [],
+      "skills": [
+        {
+          "id": "cooking",
+          "category": "trade",
+          "decayPerWeek": 0,
+          "nameKey": "stable-life.skill.cooking.name"
+        },
+        {
+          "id": "management",
+          "category": "administrative",
+          "decayPerWeek": 0,
+          "nameKey": "stable-life.skill.management.name"
+        },
+        {
+          "id": "programming",
+          "category": "technical",
+          "decayPerWeek": 0,
+          "nameKey": "stable-life.skill.programming.name"
+        }
+      ],
       "scenarioId": "scenario-stable-life",
       "goalFailurePrecedence": "goals_win",
       "sceneTemplateKey": "stable-life.scene",
@@ -276,10 +662,29 @@
     "stable-life.campaign.description": "Life in the Fast Lane — the Stable Life scenario. Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
     "stable-life.campaign.title": "Life in the Fast Lane — Stable Life",
     "stable-life.difficulty.standard.label": "Standard",
+    "stable-life.employer.bright-mart-retail.name": "BrightMart Retail",
+    "stable-life.employer.civic-data-office.name": "Civic Data Office",
+    "stable-life.employer.greasy-spoon-diner.name": "The Greasy Spoon Diner",
     "stable-life.goal.stable-life.description": "Two thousand dollars, skilled work, sixty happiness, sixty health, and nothing overdue. Twelve months.",
     "stable-life.goal.stable-life.label": "A Stable Life",
     "stable-life.housing.rented-room.description": "The cheapest housing tier. It is a room, and it is rented, and the description has now told you everything it has.",
     "stable-life.housing.rented-room.name": "Rented Room",
+    "stable-life.job.data-entry-clerk.description": "Entry tier. No credential required, per §6.1.",
+    "stable-life.job.data-entry-clerk.title": "Data Entry Clerk",
+    "stable-life.job.dishwasher.description": "Entry tier. No credential required, per §6.1 — just a sink and a willingness.",
+    "stable-life.job.dishwasher.title": "Dishwasher",
+    "stable-life.job.infrastructure-engineer.description": "Professional tier. §6.4: open positions here are finite and competed for.",
+    "stable-life.job.infrastructure-engineer.title": "Infrastructure Engineer",
+    "stable-life.job.line-cook.description": "Skilled tier — §6.1's \"demonstrated skill\" is the Cooking skill, per §6.2's requirements list.",
+    "stable-life.job.line-cook.title": "Line Cook",
+    "stable-life.job.retail-associate.description": "Entry tier. No credential required, per §6.1.",
+    "stable-life.job.retail-associate.title": "Retail Associate",
+    "stable-life.job.shift-supervisor.description": "Professional tier. §6.4: open positions here are finite and competed for.",
+    "stable-life.job.shift-supervisor.title": "Shift Supervisor",
+    "stable-life.job.systems-administrator.description": "Skilled tier — §6.1's \"demonstrated skill\" is the Programming skill, per §6.2.",
+    "stable-life.job.systems-administrator.title": "Systems Administrator",
+    "stable-life.job.wifi-scapegoat.description": "Senior tier — §6.1: scarce, track record plus reputation. §6.6's own joke ending for this chain.",
+    "stable-life.job.wifi-scapegoat.title": "Person Blamed When Wi-Fi Stops",
     "stable-life.location.bank.description": "Two hops from Home, which is exactly as far as money should be.",
     "stable-life.location.bank.name": "Bank",
     "stable-life.location.community-college.description": "Two hops from Home. §16.2.1 notes its travel cost is the first lever to move if the certificate path proves impossible rather than merely hard.",
@@ -298,6 +703,9 @@
     "stable-life.location.workplace.name": "Workplace",
     "stable-life.scenario.description": "Two hundred dollars, no job, basic education, a rented room, one week of food, and fifty-two weeks.",
     "stable-life.scenario.name": "Stable Life",
-    "stable-life.scene": "Week {week}. {location}."
+    "stable-life.scene": "Week {week}. {location}.",
+    "stable-life.skill.cooking.name": "Cooking",
+    "stable-life.skill.management.name": "Management",
+    "stable-life.skill.programming.name": "Programming"
   }
 }

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -93,14 +93,98 @@ describe("Stable Life — the authoring path", () => {
   });
 
   it("names every collection the source requires, so an unwritten one is visibly empty", () => {
-    // The seed leaves fourteen collections empty on purpose. This asserts they are present
-    // and empty rather than quietly populated by a later edit that skipped the spec.
+    // §16.1's jobs/employers/skills targets are now authored (S15); the rest are still an
+    // honest statement that the content is unwritten.
     const empty = [
-      "jobs", "courses", "items", "events", "npcs", "opportunities", "achievements",
-      "headlines", "employers", "backgrounds", "traits", "skills",
+      "courses", "items", "events", "npcs", "opportunities", "achievements",
+      "headlines", "backgrounds", "traits",
     ] as const;
     for (const key of empty) {
       expect(stableLifeSource[key], `${key} should still be unwritten`).toEqual([]);
     }
+  });
+});
+
+describe("Stable Life — jobs, employers and skills (S15)", () => {
+  const jobs = stableLifeSource.jobs;
+  const employers = stableLifeSource.employers;
+  const skills = stableLifeSource.skills;
+  const VALID_TIERS = ["entry", "skilled", "professional", "senior"] as const;
+  const TIER_RANK: Record<(typeof VALID_TIERS)[number], number> = {
+    entry: 0, skilled: 1, professional: 2, senior: 3,
+  };
+
+  it("has 8 jobs, each at one of the four §6.1 tiers (S15.1)", () => {
+    expect(jobs).toHaveLength(8);
+    for (const job of jobs) {
+      expect(VALID_TIERS, `${job.id}'s tier`).toContain(job.tier);
+    }
+  });
+
+  it("carries exactly 3 career paths, each an ascending tier sequence chained by promotionPaths (S15.2)", () => {
+    const careerPathIds = new Set(jobs.map((job) => job.careerPathId));
+    expect(careerPathIds.size).toBe(3);
+
+    for (const careerPathId of careerPathIds) {
+      const path = jobs
+        .filter((job) => job.careerPathId === careerPathId)
+        .sort((a, b) => TIER_RANK[a.tier] - TIER_RANK[b.tier]);
+      for (let i = 0; i + 1 < path.length; i++) {
+        const [current, next] = [path[i]!, path[i + 1]!];
+        expect(TIER_RANK[next.tier], `${careerPathId}: ${current.id} -> ${next.id}`).toBeGreaterThan(
+          TIER_RANK[current.tier],
+        );
+        expect(
+          current.promotionPaths.some((p) => p.toJobId === next.id),
+          `${current.id} should have a promotionPaths entry linking to ${next.id}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("names only employers and skills that exist, by iterating the collections (S15.3)", () => {
+    const employerIds = new Set(employers.map((e) => e.id));
+    const skillIds = new Set(skills.map((s) => s.id));
+    for (const job of jobs) {
+      expect(employerIds.has(job.employerId), `${job.id} names employer ${job.employerId}`).toBe(true);
+      for (const requirement of job.requirements) {
+        if (requirement.type === "skill" && "field" in requirement.condition) {
+          const skillId = requirement.condition.field.replace("player.skills.", "");
+          expect(skillIds.has(skillId), `${job.id} names skill ${skillId}`).toBe(true);
+        }
+      }
+    }
+    // Every employer's jobIds round-trip back to a job that names it.
+    for (const employer of employers) {
+      for (const jobId of employer.jobIds) {
+        const job = jobs.find((j) => j.id === jobId);
+        expect(job?.employerId, `${employer.id} names job ${jobId}`).toBe(employer.id);
+      }
+    }
+  });
+
+  it("matches §16.4's wage table exactly, and prices part-time at 55% for 5 units (S15.4)", () => {
+    const fullTimeByTier: Record<string, number> = {};
+    for (const job of jobs) {
+      fullTimeByTier[job.tier] = job.compensation.baseWeeklyPayCents;
+    }
+    expect(fullTimeByTier.entry).toBe(21_000);
+    expect(fullTimeByTier.skilled).toBe(34_000);
+    expect(fullTimeByTier.professional).toBe(52_000);
+    expect(fullTimeByTier.senior).toBe(78_000);
+
+    expect(Math.round(fullTimeByTier.entry! * 0.55)).toBe(11_550);
+    expect(Math.round(fullTimeByTier.skilled! * 0.55)).toBe(18_700);
+    expect(Math.round(fullTimeByTier.professional! * 0.55)).toBe(28_600);
+    expect(Math.round(fullTimeByTier.senior! * 0.55)).toBe(42_900);
+  });
+
+  it("builds and validates with jobs, employers and skills wired in", () => {
+    const result = buildStableLifeCampaign();
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    const registry = buildValidatedContentRegistry([built()], kinds);
+    expect(registry.errors).toEqual([]);
+    expect(registry.ok).toBe(true);
   });
 });

--- a/src/campaigns/stable-life.ts
+++ b/src/campaigns/stable-life.ts
@@ -9,11 +9,12 @@
  * nothing is copied from the engine's own `stable-life` regression fixture, which is
  * engine-owned and unpublished.
  *
- * What it deliberately does not yet carry: jobs, courses, items, events, NPCs,
- * opportunities, achievements, headlines, employers, backgrounds, traits and skills. Each
- * is its own authoring slice against §16.1's content targets. The collections are present
- * and empty rather than absent, because `SimulationCampaignSource` requires all seventeen
- * and an empty one is an honest statement that the content is unwritten.
+ * What it deliberately does not yet carry: courses, items, events, NPCs, opportunities,
+ * achievements, headlines, backgrounds and traits (jobs, employers and skills were added by
+ * S15). Each remaining collection is its own authoring slice against §16.1's content
+ * targets. They are present and empty rather than absent, because `SimulationCampaignSource`
+ * requires all seventeen and an empty one is an honest statement that the content is
+ * unwritten.
  *
  * **One completion requirement from §16.3 is not expressible today.** "Education:
  * certificate or better" needs a condition over `player.education.credentials`, which is a
@@ -172,6 +173,342 @@ const housing: SimulationCampaignSource["housing"] = [
 ];
 
 /**
+ * §16.4's wage table, by tier. Cited once here rather than re-typed into each job's
+ * `compensation`, so a rate change touches one place. Part-time pays 55% of the full-time
+ * rate for 5 time units (§16.4); `JobDefinition` has no separate part-time variant, and
+ * doubling the eight jobs S15.1 targets to author one would blow the §16.1 content count,
+ * so the part-time figure stays a computed constant here rather than authored content.
+ */
+const WAGE_TABLE_CENTS: Record<"entry" | "skilled" | "professional" | "senior", number> = {
+  entry: DOLLARS(210),
+  skilled: DOLLARS(340),
+  professional: DOLLARS(520),
+  senior: DOLLARS(780),
+};
+
+/**
+ * §3.5 — skills referenced by the job requirements below. Only the three actually named by
+ * a requirement are authored; the rest of §3.5's example list is unclaimed content, not an
+ * omission. Ids are bare (`cooking`, not `skill-cooking`) because `player.skills.<id>`
+ * (`derived.ts`) keys directly off `SkillDefinition.id` — a prefix here would desync the id
+ * from the field every requirement below reads it through.
+ */
+const skills: SimulationCampaignSource["skills"] = [
+  {
+    id: "cooking",
+    name: { key: "stable-life.skill.cooking.name", text: "Cooking" },
+    category: "trade",
+    decayPerWeek: 0,
+  },
+  {
+    id: "management",
+    name: { key: "stable-life.skill.management.name", text: "Management" },
+    category: "administrative",
+    decayPerWeek: 0,
+  },
+  {
+    id: "programming",
+    name: { key: "stable-life.skill.programming.name", text: "Programming" },
+    category: "technical",
+    decayPerWeek: 0,
+  },
+];
+
+/**
+ * §16.1 — the eight jobs, in the three §16.1 career paths. Titles for two of the three
+ * paths are §6.6's own worked examples verbatim (the third, `career-retail`, is its first
+ * rung only — an eight-job budget across three paths does not stretch to all of every
+ * example chain). Tiers are §6.1's four names; `professional`/`senior` postings are
+ * `contested: true` per §6.4's "finite and competed for. See §14.3."
+ */
+const jobs: SimulationCampaignSource["jobs"] = [
+  // career-food-service — §6.6's first example chain, first three rungs.
+  {
+    id: "job-dishwasher",
+    title: { key: "stable-life.job.dishwasher.title", text: "Dishwasher" },
+    description: {
+      key: "stable-life.job.dishwasher.description",
+      text: "Entry tier. No credential required, per §6.1 — just a sink and a willingness.",
+    },
+    employerId: "employer-greasy-spoon-diner",
+    careerPathId: "career-food-service",
+    tier: "entry",
+    schedule: { weeklyTimeCost: 10, flexibility: 10 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.entry },
+    requirements: [],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [
+      {
+        toJobId: "job-line-cook",
+        minimumWeeksInRole: 8,
+        minimumPerformance: 40,
+        requirements: [],
+        contested: false,
+        baseChance: 85,
+      },
+    ],
+    terminationRules: [],
+    contested: false,
+    tags: ["career-food-service"],
+  },
+  {
+    id: "job-line-cook",
+    title: { key: "stable-life.job.line-cook.title", text: "Line Cook" },
+    description: {
+      key: "stable-life.job.line-cook.description",
+      text: "Skilled tier — §6.1's \"demonstrated skill\" is the Cooking skill, per §6.2's requirements list.",
+    },
+    employerId: "employer-greasy-spoon-diner",
+    careerPathId: "career-food-service",
+    tier: "skilled",
+    schedule: { weeklyTimeCost: 9, flexibility: 20 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.skilled },
+    requirements: [
+      {
+        type: "skill",
+        condition: { field: "player.skills.cooking", operator: "greater_or_equal", value: 25 },
+        failureCode: "requirement_unmet",
+        messageKey: "stable-life.job.line-cook.requirement.cooking",
+      },
+    ],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [
+      {
+        toJobId: "job-shift-supervisor",
+        minimumWeeksInRole: 12,
+        minimumPerformance: 55,
+        requirements: [
+          {
+            type: "skill",
+            condition: { field: "player.skills.management", operator: "greater_or_equal", value: 40 },
+            failureCode: "requirement_unmet",
+            messageKey: "stable-life.job.shift-supervisor.requirement.management",
+          },
+        ],
+        contested: true,
+        baseChance: 50,
+      },
+    ],
+    terminationRules: [],
+    contested: false,
+    tags: ["career-food-service"],
+  },
+  {
+    id: "job-shift-supervisor",
+    title: { key: "stable-life.job.shift-supervisor.title", text: "Shift Supervisor" },
+    description: {
+      key: "stable-life.job.shift-supervisor.description",
+      text: "Professional tier. §6.4: open positions here are finite and competed for.",
+    },
+    employerId: "employer-greasy-spoon-diner",
+    careerPathId: "career-food-service",
+    tier: "professional",
+    schedule: { weeklyTimeCost: 8, flexibility: 30 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.professional },
+    requirements: [
+      {
+        type: "skill",
+        condition: { field: "player.skills.management", operator: "greater_or_equal", value: 40 },
+        failureCode: "requirement_unmet",
+        messageKey: "stable-life.job.shift-supervisor.requirement.management",
+      },
+    ],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [],
+    terminationRules: [],
+    contested: true,
+    positionsAvailable: 2,
+    tags: ["career-food-service"],
+  },
+
+  // career-clerical — §6.6's second example chain, in full, including its own joke title.
+  {
+    id: "job-data-entry-clerk",
+    title: { key: "stable-life.job.data-entry-clerk.title", text: "Data Entry Clerk" },
+    description: {
+      key: "stable-life.job.data-entry-clerk.description",
+      text: "Entry tier. No credential required, per §6.1.",
+    },
+    employerId: "employer-civic-data-office",
+    careerPathId: "career-clerical",
+    tier: "entry",
+    schedule: { weeklyTimeCost: 10, flexibility: 10 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.entry },
+    requirements: [],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [
+      {
+        toJobId: "job-systems-administrator",
+        minimumWeeksInRole: 8,
+        minimumPerformance: 40,
+        requirements: [],
+        contested: false,
+        baseChance: 85,
+      },
+    ],
+    terminationRules: [],
+    contested: false,
+    tags: ["career-clerical"],
+  },
+  {
+    id: "job-systems-administrator",
+    title: { key: "stable-life.job.systems-administrator.title", text: "Systems Administrator" },
+    description: {
+      key: "stable-life.job.systems-administrator.description",
+      text: "Skilled tier — §6.1's \"demonstrated skill\" is the Programming skill, per §6.2.",
+    },
+    employerId: "employer-civic-data-office",
+    careerPathId: "career-clerical",
+    tier: "skilled",
+    schedule: { weeklyTimeCost: 9, flexibility: 25 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.skilled },
+    requirements: [
+      {
+        type: "skill",
+        condition: { field: "player.skills.programming", operator: "greater_or_equal", value: 25 },
+        failureCode: "requirement_unmet",
+        messageKey: "stable-life.job.systems-administrator.requirement.programming",
+      },
+    ],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [
+      {
+        toJobId: "job-infrastructure-engineer",
+        minimumWeeksInRole: 12,
+        minimumPerformance: 55,
+        requirements: [
+          {
+            type: "skill",
+            condition: { field: "player.skills.programming", operator: "greater_or_equal", value: 55 },
+            failureCode: "requirement_unmet",
+            messageKey: "stable-life.job.infrastructure-engineer.requirement.programming",
+          },
+        ],
+        contested: true,
+        baseChance: 55,
+      },
+    ],
+    terminationRules: [],
+    contested: false,
+    tags: ["career-clerical"],
+  },
+  {
+    id: "job-infrastructure-engineer",
+    title: { key: "stable-life.job.infrastructure-engineer.title", text: "Infrastructure Engineer" },
+    description: {
+      key: "stable-life.job.infrastructure-engineer.description",
+      text: "Professional tier. §6.4: open positions here are finite and competed for.",
+    },
+    employerId: "employer-civic-data-office",
+    careerPathId: "career-clerical",
+    tier: "professional",
+    schedule: { weeklyTimeCost: 8, flexibility: 35 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.professional },
+    requirements: [
+      {
+        type: "skill",
+        condition: { field: "player.skills.programming", operator: "greater_or_equal", value: 55 },
+        failureCode: "requirement_unmet",
+        messageKey: "stable-life.job.infrastructure-engineer.requirement.programming",
+      },
+    ],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [
+      {
+        toJobId: "job-wifi-scapegoat",
+        minimumWeeksInRole: 16,
+        minimumPerformance: 65,
+        requirements: [],
+        contested: true,
+        baseChance: 35,
+      },
+    ],
+    terminationRules: [],
+    contested: true,
+    positionsAvailable: 2,
+    tags: ["career-clerical"],
+  },
+  {
+    id: "job-wifi-scapegoat",
+    title: { key: "stable-life.job.wifi-scapegoat.title", text: "Person Blamed When Wi-Fi Stops" },
+    description: {
+      key: "stable-life.job.wifi-scapegoat.description",
+      text: "Senior tier — §6.1: scarce, track record plus reputation. §6.6's own joke ending for this chain.",
+    },
+    employerId: "employer-civic-data-office",
+    careerPathId: "career-clerical",
+    tier: "senior",
+    schedule: { weeklyTimeCost: 8, flexibility: 40 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.senior },
+    requirements: [],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [],
+    terminationRules: [],
+    contested: true,
+    positionsAvailable: 1,
+    tags: ["career-clerical"],
+  },
+
+  // career-retail — §6.6's third example chain, first rung only (see file-level note above).
+  {
+    id: "job-retail-associate",
+    title: { key: "stable-life.job.retail-associate.title", text: "Retail Associate" },
+    description: {
+      key: "stable-life.job.retail-associate.description",
+      text: "Entry tier. No credential required, per §6.1.",
+    },
+    employerId: "employer-bright-mart-retail",
+    careerPathId: "career-retail",
+    tier: "entry",
+    schedule: { weeklyTimeCost: 10, flexibility: 15 },
+    compensation: { baseWeeklyPayCents: WAGE_TABLE_CENTS.entry },
+    requirements: [],
+    performance: { factors: [], weeklyDriftToward: 50, minimumAcceptable: 30 },
+    promotionPaths: [],
+    terminationRules: [],
+    contested: false,
+    tags: ["career-retail"],
+  },
+];
+
+/** §6 names no field this pinned engine cannot express — `Requirement`, `PerformanceFactor`,
+ *  `PromotionPath` and `TerminationRule` already cover §6.2–§6.5 in full. Nothing is omitted
+ *  here under CP10; the empty `performance.factors` and `terminationRules` above are this
+ *  slice's own scope choice (S16 is where weeks, and job outcomes within them, start going
+ *  wrong on their own), not an engine gap. */
+
+/**
+ * §16.1/§6 — the three employers the eight jobs above name. `npcIds` stays empty; NPCs are
+ * S20, not this slice.
+ */
+const employers: SimulationCampaignSource["employers"] = [
+  {
+    id: "employer-greasy-spoon-diner",
+    name: { key: "stable-life.employer.greasy-spoon-diner.name", text: "The Greasy Spoon Diner" },
+    sector: "food-service",
+    reputation: 40,
+    jobIds: ["job-dishwasher", "job-line-cook", "job-shift-supervisor"],
+    npcIds: [],
+  },
+  {
+    id: "employer-civic-data-office",
+    name: { key: "stable-life.employer.civic-data-office.name", text: "Civic Data Office" },
+    sector: "clerical",
+    reputation: 55,
+    jobIds: ["job-data-entry-clerk", "job-systems-administrator", "job-infrastructure-engineer", "job-wifi-scapegoat"],
+    npcIds: [],
+  },
+  {
+    id: "employer-bright-mart-retail",
+    name: { key: "stable-life.employer.bright-mart-retail.name", text: "BrightMart Retail" },
+    sector: "retail",
+    reputation: 50,
+    jobIds: ["job-retail-associate"],
+    npcIds: [],
+  },
+];
+
+/**
  * §16.3's completion requirements, minus the credential one the condition language cannot
  * express yet (see the file header). `highestTierAchieved` is a string, so "skilled or
  * better" is authored as the explicit set rather than an ordering comparison — the tier
@@ -245,7 +582,7 @@ export const stableLifeSource: SimulationCampaignSource = {
     text: "Life in the Fast Lane — the Stable Life scenario. Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
   },
 
-  jobs: [],
+  jobs,
   courses: [],
   housing,
   items: [],
@@ -257,11 +594,11 @@ export const stableLifeSource: SimulationCampaignSource = {
   opportunities: [],
   achievements: [],
   headlines: [],
-  employers: [],
+  employers,
   locations,
   backgrounds: [],
   traits: [],
-  skills: [],
+  skills,
 
   scenarioId: STABLE_LIFE_SCENARIO_ID,
   goalFailurePrecedence: "goals_win",
@@ -294,7 +631,7 @@ export const stableLifeCatalog = {
     "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
   duration: "52 weeks",
   contentNotice:
-    "Seed content. The map and the scenario are authored; jobs, courses, events and possessions are not yet written.",
+    "Seed content. The map, the scenario and the career ladder are authored; courses, events and possessions are not yet written.",
   featured: false,
   hidden: true,
 } as const;


### PR DESCRIPTION
## Summary

Authors §16.1's 8 jobs across 3 career paths, the 3 employers they belong to, and the 3 skills their requirements/promotion gates reference — the first content-authoring slice against the Career System (§6).

- **career-food-service** (Greasy Spoon Diner): Dishwasher (entry) → Line Cook (skilled, requires Cooking) → Shift Supervisor (professional, contested, requires Management)
- **career-clerical** (Civic Data Office): Data Entry Clerk (entry) → Systems Administrator (skilled, requires Programming) → Infrastructure Engineer (professional, contested) → Person Blamed When Wi-Fi Stops (senior, contested, scarce) — §6.6's second example chain in full, including its own joke title
- **career-retail** (BrightMart Retail): Retail Associate (entry) — §6.6's third example chain, first rung only (an 8-job budget across 3 paths doesn't stretch to every chain in full)

Full-time weekly pay matches §16.4's wage table exactly (entry $210 / skilled $340 / professional $520 / senior $780, in cents). Part-time's 55%-for-5-units figure is a computed constant off the same wage table rather than 8 more authored job entries, since `JobDefinition` has no separate part-time variant and doubling the job count would blow the §16.1 content target.

## Acceptance criteria (S15)

- [x] S15.1 — 8 jobs, every tier one of the four §6.1 names
- [x] S15.2 — 3 distinct careerPathIds, each an ascending tier sequence linked by `promotionPaths`
- [x] S15.3 — every `employerId`/skill a job names exists in `employers`/`skills`, iterated rather than restated
- [x] S15.4 — wage table exact match plus part-time 55%/5-unit math, asserted in cents
- [x] S15.5 — every job cites its §03 section in a comment
- [x] S15.6 — nothing in §6 is inexpressible by the pinned engine; no CP10 omission needed (`Requirement`, `PerformanceFactor`, `PromotionPath`, `TerminationRule` already cover §6.2–§6.5 in full)
- [x] S15.7 — `npm run check` passes; `content/stable-life.json` and `content/manifest.json` regenerated in this commit, digest moved

## Descriptive correction

None — no drift found between `design/` and the tree while implementing this slice.

## Out of scope (per the slice)

Events firing on employment (S16), the courses a job requirement may cite (S17), and any balance change to §16.4's numbers.

## Verified

Gates were run in this session:

- `npm run typecheck` — passes
- `npm test` (vitest) — 24/24 passing, including the 6 new S15 tests in `stable-life.test.ts` (each verified to fail before the content existed, for the right reason)
- `npm run export:content` — regenerated `content/stable-life.json` and `content/manifest.json`, committed in the same commit
- `npm run check:clean` — `content/` matches sources
- `git diff --check` — clean
- `git status --short` — clean after the full `npm run check` pipeline

Not run: the design-state checker (`tools/Test-DesignState.ps1`) and CI itself — those run on the PR; report their outcome once available rather than assuming it here.