### PR TITLE
S16 — Weeks stop being identical: work, money and paperwork go wrong on their own

### DIFF
--- a/.claude/verify-report.json
+++ b/.claude/verify-report.json
@@ -3,12 +3,12 @@
     {
       "name": "Parse-check PowerShell scripts",
       "status": "Passed",
-      "detail": "All *.ps1 files parsed with System.Management.Automation.Language.Parser, zero parse errors."
+      "detail": "All 73 *.ps1 files parsed with System.Management.Automation.Language.Parser, zero parse errors."
     },
     {
       "name": "Run Pester tests",
       "status": "Passed",
-      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 319.86s. Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0."
+      "detail": "Invoke-Pester -Path tools -Output Detailed -PassThru: Tests completed in 188.62s. Tests Passed: 350, Failed: 0, Skipped: 0, NotRun: 0."
     },
     {
       "name": "Validate the core/companion split",
@@ -38,7 +38,7 @@
     {
       "name": "Test the campaign sources",
       "status": "Passed",
-      "detail": "npm test: vitest run - Test Files 4 passed (4), Tests 19 passed (19), exit 0. Includes the 5 new tests in src/check-clean.test.ts covering CP11/CP12/CP13."
+      "detail": "npm test: vitest run - Test Files 4 passed (4), Tests 29 passed (29), exit 0. Includes the 5 new S16 tests in src/campaigns/stable-life.test.ts (each verified to fail before the events/evaluator existed, for the right reason)."
     },
     {
       "name": "Re-export content and fail if the committed JSON is stale",

--- a/content/manifest.json
+++ b/content/manifest.json
@@ -5,7 +5,7 @@
       "file": "stable-life.json",
       "id": "life-in-the-fast-lane-stable-life",
       "version": "0.1.0",
-      "digest": "sha-256:29e6dcfdc8aa16b609a6174269b4040edcf20bb6c31f1975836578e49e127a3e"
+      "digest": "sha-256:f22f174bf9ff5f1f427269b37cbc7248f26803595031fbe447f7553e9dd82a06"
     }
   ],
   "resolution": "sha-256:69d83e73ed1b957f9f09ff86d146b21f928b91748108f76b806f403b0ae112d4"

--- a/content/stable-life.json
+++ b/content/stable-life.json
@@ -4,7 +4,7 @@
     "title": "Life in the Fast Lane — Stable Life",
     "description": "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
     "duration": "52 weeks",
-    "contentNotice": "Seed content. The map, the scenario and the career ladder are authored; courses, events and possessions are not yet written.",
+    "contentNotice": "Seed content. The map, the scenario, the career ladder and 15 of 30 random events are authored; courses and possessions are not yet written.",
     "featured": false,
     "hidden": true
   },
@@ -373,7 +373,656 @@
         }
       ],
       "items": [],
-      "events": [],
+      "events": [
+        {
+          "id": "event-shift-schedule-cut",
+          "category": "employment",
+          "weight": 12,
+          "conditions": {
+            "field": "player.career.currentEmployment",
+            "operator": "not_equals"
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 6,
+                "sourceId": "event-shift-schedule-cut"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -4000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.shift-schedule-cut.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "conditional"
+          ],
+          "titleKey": "stable-life.event.shift-schedule-cut.title",
+          "descriptionKey": "stable-life.event.shift-schedule-cut.description"
+        },
+        {
+          "id": "event-surprise-bonus",
+          "category": "employment",
+          "weight": 6,
+          "conditions": {
+            "field": "player.career.currentEmployment",
+            "operator": "not_equals"
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.happiness",
+                "operation": "add",
+                "value": 8,
+                "sourceId": "event-surprise-bonus"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": 5000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.surprise-bonus.outcome.message",
+                "visible": true,
+                "tone": "positive"
+              }
+            ]
+          },
+          "tags": [
+            "conditional"
+          ],
+          "titleKey": "stable-life.event.surprise-bonus.title",
+          "descriptionKey": "stable-life.event.surprise-bonus.description"
+        },
+        {
+          "id": "event-job-interview-invitation",
+          "category": "employment",
+          "weight": 10,
+          "conditions": {
+            "field": "player.career.currentEmployment",
+            "operator": "equals"
+          },
+          "choices": [
+            {
+              "id": "attend-interview",
+              "labelKey": "stable-life.event.job-interview-invitation.choice.attend-interview",
+              "timeCost": 3,
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [
+                      {
+                        "target": "player.needs.stress",
+                        "operation": "add",
+                        "value": 5,
+                        "sourceId": "event-job-interview-invitation"
+                      }
+                    ],
+                    "rewards": [],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.job-interview-invitation.outcome.attended",
+                        "visible": true,
+                        "tone": "neutral"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "skip-interview",
+              "labelKey": "stable-life.event.job-interview-invitation.choice.skip-interview",
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [],
+                    "rewards": [],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.job-interview-invitation.outcome.skipped",
+                        "visible": true,
+                        "tone": "neutral"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "conditional"
+          ],
+          "titleKey": "stable-life.event.job-interview-invitation.title",
+          "descriptionKey": "stable-life.event.job-interview-invitation.description"
+        },
+        {
+          "id": "event-inflation-adjustment",
+          "category": "economy",
+          "weight": 15,
+          "conditions": {
+            "all": []
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 3,
+                "sourceId": "event-inflation-adjustment"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -1500
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.inflation-adjustment.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "world-triggered"
+          ],
+          "titleKey": "stable-life.event.inflation-adjustment.title",
+          "descriptionKey": "stable-life.event.inflation-adjustment.description"
+        },
+        {
+          "id": "event-hardship-relief-payment",
+          "category": "economy",
+          "weight": 5,
+          "unique": true,
+          "conditions": {
+            "field": "player.finances.cashCents",
+            "operator": "less_than",
+            "value": 5000
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.happiness",
+                "operation": "add",
+                "value": 5,
+                "sourceId": "event-hardship-relief-payment"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": 8000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.hardship-relief-payment.outcome.message",
+                "visible": true,
+                "tone": "positive"
+              }
+            ]
+          },
+          "tags": [
+            "unique"
+          ],
+          "titleKey": "stable-life.event.hardship-relief-payment.title",
+          "descriptionKey": "stable-life.event.hardship-relief-payment.description"
+        },
+        {
+          "id": "event-appliance-breaks",
+          "category": "purchases",
+          "weight": 10,
+          "conditions": {
+            "all": []
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 4,
+                "sourceId": "event-appliance-breaks"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -3500
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.appliance-breaks.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "immediate"
+          ],
+          "titleKey": "stable-life.event.appliance-breaks.title",
+          "descriptionKey": "stable-life.event.appliance-breaks.description"
+        },
+        {
+          "id": "event-limited-time-sale",
+          "category": "purchases",
+          "weight": 8,
+          "conditions": {
+            "all": []
+          },
+          "choices": [
+            {
+              "id": "buy-now",
+              "labelKey": "stable-life.event.limited-time-sale.choice.buy-now",
+              "moneyCostCents": 2000,
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [
+                      {
+                        "target": "player.needs.happiness",
+                        "operation": "add",
+                        "value": 4,
+                        "sourceId": "event-limited-time-sale"
+                      }
+                    ],
+                    "rewards": [],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.limited-time-sale.outcome.bought",
+                        "visible": true,
+                        "tone": "positive"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "skip-sale",
+              "labelKey": "stable-life.event.limited-time-sale.choice.skip-sale",
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [],
+                    "rewards": [],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.limited-time-sale.outcome.skipped",
+                        "visible": true,
+                        "tone": "neutral"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "repeatable"
+          ],
+          "titleKey": "stable-life.event.limited-time-sale.title",
+          "descriptionKey": "stable-life.event.limited-time-sale.description"
+        },
+        {
+          "id": "event-pickpocketed",
+          "category": "crime",
+          "weight": 6,
+          "conditions": {
+            "field": "player.finances.cashCents",
+            "operator": "greater_than",
+            "value": 0
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 8,
+                "sourceId": "event-pickpocketed"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -2000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.pickpocketed.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "conditional"
+          ],
+          "titleKey": "stable-life.event.pickpocketed.title",
+          "descriptionKey": "stable-life.event.pickpocketed.description"
+        },
+        {
+          "id": "event-mugging-attempt",
+          "category": "crime",
+          "weight": 4,
+          "conditions": {
+            "all": []
+          },
+          "choices": [
+            {
+              "id": "hand-over-wallet",
+              "labelKey": "stable-life.event.mugging-attempt.choice.hand-over-wallet",
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [
+                      {
+                        "target": "player.needs.stress",
+                        "operation": "add",
+                        "value": 10,
+                        "sourceId": "event-mugging-attempt"
+                      }
+                    ],
+                    "rewards": [
+                      {
+                        "type": "money",
+                        "target": "player.finances.cashCents",
+                        "value": -3000
+                      }
+                    ],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.mugging-attempt.outcome.handed-over",
+                        "visible": true,
+                        "tone": "negative"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "run-away",
+              "labelKey": "stable-life.event.mugging-attempt.choice.run-away",
+              "outcomes": [
+                {
+                  "outcome": {
+                    "effects": [
+                      {
+                        "target": "player.needs.stress",
+                        "operation": "add",
+                        "value": 6,
+                        "sourceId": "event-mugging-attempt"
+                      },
+                      {
+                        "target": "player.needs.energy",
+                        "operation": "subtract",
+                        "value": 5,
+                        "sourceId": "event-mugging-attempt"
+                      }
+                    ],
+                    "rewards": [],
+                    "messages": [
+                      {
+                        "key": "stable-life.event.mugging-attempt.outcome.ran-away",
+                        "visible": true,
+                        "tone": "neutral"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "world-triggered"
+          ],
+          "titleKey": "stable-life.event.mugging-attempt.title",
+          "descriptionKey": "stable-life.event.mugging-attempt.description"
+        },
+        {
+          "id": "event-late-tax-filing-notice",
+          "category": "bureaucracy",
+          "weight": 7,
+          "conditions": {
+            "all": []
+          },
+          "chainId": "tax-filing-chain",
+          "chainStep": 1,
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 5,
+                "sourceId": "event-late-tax-filing-notice"
+              }
+            ],
+            "rewards": [],
+            "messages": [
+              {
+                "key": "stable-life.event.late-tax-filing-notice.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ],
+            "scheduledEvents": [
+              {
+                "eventId": "event-tax-penalty-assessment",
+                "inWeeks": 2
+              }
+            ]
+          },
+          "tags": [
+            "chained"
+          ],
+          "titleKey": "stable-life.event.late-tax-filing-notice.title",
+          "descriptionKey": "stable-life.event.late-tax-filing-notice.description"
+        },
+        {
+          "id": "event-tax-penalty-assessment",
+          "category": "bureaucracy",
+          "weight": 0,
+          "conditions": {
+            "all": []
+          },
+          "chainId": "tax-filing-chain",
+          "chainStep": 2,
+          "automaticOutcome": {
+            "effects": [],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -4500
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.tax-penalty-assessment.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ],
+            "endsChain": true
+          },
+          "tags": [
+            "chained"
+          ],
+          "titleKey": "stable-life.event.tax-penalty-assessment.title",
+          "descriptionKey": "stable-life.event.tax-penalty-assessment.description"
+        },
+        {
+          "id": "event-bus-fare-increase",
+          "category": "transportation",
+          "weight": 12,
+          "cooldownWeeks": 8,
+          "conditions": {
+            "all": []
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 2,
+                "sourceId": "event-bus-fare-increase"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -500
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.bus-fare-increase.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "recurring"
+          ],
+          "titleKey": "stable-life.event.bus-fare-increase.title",
+          "descriptionKey": "stable-life.event.bus-fare-increase.description"
+        },
+        {
+          "id": "event-car-breakdown",
+          "category": "transportation",
+          "weight": 3,
+          "conditions": {
+            "all": []
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.stress",
+                "operation": "add",
+                "value": 7,
+                "sourceId": "event-car-breakdown"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": -6000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.car-breakdown.outcome.message",
+                "visible": true,
+                "tone": "negative"
+              }
+            ]
+          },
+          "tags": [
+            "world-triggered"
+          ],
+          "titleKey": "stable-life.event.car-breakdown.title",
+          "descriptionKey": "stable-life.event.car-breakdown.description"
+        },
+        {
+          "id": "event-team-morale-day",
+          "category": "business",
+          "weight": 9,
+          "conditions": {
+            "all": []
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.happiness",
+                "operation": "add",
+                "value": 6,
+                "sourceId": "event-team-morale-day"
+              }
+            ],
+            "rewards": [],
+            "messages": [
+              {
+                "key": "stable-life.event.team-morale-day.outcome.message",
+                "visible": true,
+                "tone": "positive"
+              }
+            ]
+          },
+          "tags": [
+            "world-triggered"
+          ],
+          "titleKey": "stable-life.event.team-morale-day.title",
+          "descriptionKey": "stable-life.event.team-morale-day.description"
+        },
+        {
+          "id": "event-employee-of-the-month",
+          "category": "business",
+          "weight": 4,
+          "unique": true,
+          "conditions": {
+            "field": "player.career.currentEmployment",
+            "operator": "not_equals"
+          },
+          "automaticOutcome": {
+            "effects": [
+              {
+                "target": "player.needs.happiness",
+                "operation": "add",
+                "value": 10,
+                "sourceId": "event-employee-of-the-month"
+              }
+            ],
+            "rewards": [
+              {
+                "type": "money",
+                "target": "player.finances.cashCents",
+                "value": 10000
+              }
+            ],
+            "messages": [
+              {
+                "key": "stable-life.event.employee-of-the-month.outcome.message",
+                "visible": true,
+                "tone": "positive"
+              }
+            ]
+          },
+          "tags": [
+            "unique"
+          ],
+          "titleKey": "stable-life.event.employee-of-the-month.title",
+          "descriptionKey": "stable-life.event.employee-of-the-month.description"
+        }
+      ],
       "npcs": [],
       "goals": [
         {
@@ -665,6 +1314,36 @@
     "stable-life.employer.bright-mart-retail.name": "BrightMart Retail",
     "stable-life.employer.civic-data-office.name": "Civic Data Office",
     "stable-life.employer.greasy-spoon-diner.name": "The Greasy Spoon Diner",
+    "stable-life.event.appliance-breaks.description": "It gives one last hum and stops. Everything in it has opinions about that now.",
+    "stable-life.event.appliance-breaks.title": "The Fridge Dies",
+    "stable-life.event.bus-fare-increase.description": "The board votes on a Tuesday no one attends. The fare box votes every day after.",
+    "stable-life.event.bus-fare-increase.title": "Fare Goes Up Again",
+    "stable-life.event.car-breakdown.description": "Something under the hood decides today is the day.",
+    "stable-life.event.car-breakdown.title": "Car Breakdown",
+    "stable-life.event.employee-of-the-month.description": "A laminated certificate and a small cash bonus, in that order of perceived value.",
+    "stable-life.event.employee-of-the-month.title": "Employee of the Month",
+    "stable-life.event.hardship-relief-payment.description": "A form filed months ago is finally worth something.",
+    "stable-life.event.hardship-relief-payment.title": "Hardship Relief Payment",
+    "stable-life.event.inflation-adjustment.description": "Nothing on the shelf changed except the number under it.",
+    "stable-life.event.inflation-adjustment.title": "Prices Creep Up",
+    "stable-life.event.job-interview-invitation.description": "Someone read the application after all, and wants to meet the person who wrote it.",
+    "stable-life.event.job-interview-invitation.title": "Interview Invitation",
+    "stable-life.event.late-tax-filing-notice.description": "A form due last season is due again, this time with a tone.",
+    "stable-life.event.late-tax-filing-notice.title": "Late Filing Notice",
+    "stable-life.event.limited-time-sale.description": "A sign in the window insists this will never happen again. It happened last month too.",
+    "stable-life.event.limited-time-sale.title": "Limited-Time Sale",
+    "stable-life.event.mugging-attempt.description": "Someone blocks the alley shortcut and asks, not very politely, for your wallet.",
+    "stable-life.event.mugging-attempt.title": "Mugging Attempt",
+    "stable-life.event.pickpocketed.description": "A crowd, a jostle, and a lighter pocket than you started the day with.",
+    "stable-life.event.pickpocketed.title": "Pickpocketed",
+    "stable-life.event.shift-schedule-cut.description": "The schedule changes and a shift disappears from under you. The rent does not follow suit.",
+    "stable-life.event.shift-schedule-cut.title": "Shift Cut Short",
+    "stable-life.event.surprise-bonus.description": "The till balanced for once, and some of the difference lands in your pay.",
+    "stable-life.event.surprise-bonus.title": "Surprise Bonus",
+    "stable-life.event.tax-penalty-assessment.description": "The tone from two weeks ago becomes a number.",
+    "stable-life.event.tax-penalty-assessment.title": "Penalty Assessment",
+    "stable-life.event.team-morale-day.description": "Someone brought a cake. It is being treated as a major event.",
+    "stable-life.event.team-morale-day.title": "Team Morale Day",
     "stable-life.goal.stable-life.description": "Two thousand dollars, skilled work, sixty happiness, sixty health, and nothing overdue. Twelve months.",
     "stable-life.goal.stable-life.label": "A Stable Life",
     "stable-life.housing.rented-room.description": "The cheapest housing tier. It is a room, and it is rented, and the description has now told you everything it has.",

--- a/design/90-decisions.md
+++ b/design/90-decisions.md
@@ -5,6 +5,9 @@ Append-only. Newest at the top. The rejected alternatives are the point — with
 ## Open
 <A staging area, not a home. Things noticed mid-slice that were deliberately not acted on. `/track` turns each into a GitHub issue and removes it from here. An item that is a *decision* rather than a *todo* belongs below as an entry, not in an issue.>
 
+- **S16.5** — `03` §11.3's collection quantifiers (`exists`/`count`) are not expressible by the pinned engine: `kinds/simulation/conditions.ts` implements `field` and throws on `collection`. 2 of the 15 S16 events would have used one and omit it instead, named at the authoring site per CP10: `event-job-interview-invitation` (would gate on a `count` over `player.career.pendingApplications`) and `event-car-breakdown` (would gate on an `exists` over `player.inventory` for an owned vehicle). Same underlying gap as the credential completion requirement `stable-life.ts`'s file header already notes for S15's goal.
+- Discovered while implementing S16.3, not this slice's to fix (out of `Touches`): `createEngine().createGame(...)` throws for the Stable Life campaign — `kinds/simulation/initial.ts`'s `buildPlayer` indexes `backgrounds[0]!.id` unconditionally, and `stableLifeSource.backgrounds` is still empty. No game session can be created for this campaign until S22 ("a player does not start from nowhere") authors at least one background.
+
 ---
 
 ### 2026-08-30 — /kit-sync merges four AGENTS.md additions; no other kit-owned file diverged

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -12,6 +12,7 @@ import {
   buildValidatedContentRegistry,
   simulationKind,
   type BuiltCampaign,
+  type Condition,
   type KindRegistry,
 } from "@the-running-dev/game-engine";
 import { toPortable } from "@the-running-dev/game-engine/authoring";
@@ -93,10 +94,10 @@ describe("Stable Life — the authoring path", () => {
   });
 
   it("names every collection the source requires, so an unwritten one is visibly empty", () => {
-    // §16.1's jobs/employers/skills targets are now authored (S15); the rest are still an
-    // honest statement that the content is unwritten.
+    // §16.1's jobs/employers/skills targets are now authored (S15), and 15 of 30 events
+    // (S16); the rest are still an honest statement that the content is unwritten.
     const empty = [
-      "courses", "items", "events", "npcs", "opportunities", "achievements",
+      "courses", "items", "npcs", "opportunities", "achievements",
       "headlines", "backgrounds", "traits",
     ] as const;
     for (const key of empty) {
@@ -180,6 +181,162 @@ describe("Stable Life — jobs, employers and skills (S15)", () => {
   });
 
   it("builds and validates with jobs, employers and skills wired in", () => {
+    const result = buildStableLifeCampaign();
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    const registry = buildValidatedContentRegistry([built()], kinds);
+    expect(registry.errors).toEqual([]);
+    expect(registry.ok).toBe(true);
+  });
+});
+
+describe("Stable Life — random events (S16)", () => {
+  const events = stableLifeSource.events;
+
+  // `03` §11.1's fourteen event categories, kebab-cased; S16 draws only from the seven this
+  // slice scopes (S16.1's "Out of scope" line names Housing/Health/etc. for later slices).
+  const REQUIRED_CATEGORIES = [
+    "employment", "economy", "purchases", "crime", "bureaucracy", "transportation", "business",
+  ] as const;
+
+  // `03` §11.2's ten event types, kebab-cased.
+  const VALID_TYPES = new Set([
+    "immediate", "delayed", "recurring", "conditional", "chained",
+    "player-triggered", "npc-triggered", "world-triggered", "unique", "repeatable",
+  ]);
+
+  it("has 15 entries, drawn only from the seven scoped categories, each represented at least once (S16.1)", () => {
+    expect(events).toHaveLength(15);
+    const categories = new Set(events.map((e) => e.category));
+    for (const event of events) {
+      expect(REQUIRED_CATEGORIES as readonly string[], `${event.id}'s category`).toContain(event.category);
+    }
+    for (const category of REQUIRED_CATEGORIES) {
+      expect(categories.has(category), `no event names category "${category}"`).toBe(true);
+    }
+  });
+
+  it("names its category and its type, both drawn from the corpus's closed lists (S16.2)", () => {
+    for (const event of events) {
+      expect(REQUIRED_CATEGORIES as readonly string[], `${event.id}'s category`).toContain(event.category);
+      const typeTags = event.tags.filter((t) => VALID_TYPES.has(t));
+      expect(typeTags, `${event.id} should carry exactly one §11.2 type tag`).toHaveLength(1);
+    }
+  });
+
+  /** A minimal mirror of the engine's own `evaluateCondition`/`compare` (`core/condition/
+   *  evaluate.ts`) — reimplemented here, not imported, because CP1 forbids reaching past the
+   *  published surface even from a test. Scoped to exactly the operators this campaign's own
+   *  conditions use; `exists`/`count` are unreachable by construction (S16.5) and throw if
+   *  ever authored, so a future quantifier is caught here rather than silently mishandled. */
+  function evaluateTestCondition(condition: Condition, resolveField: (path: string) => unknown): boolean {
+    if ("all" in condition) return condition.all.every((c) => evaluateTestCondition(c, resolveField));
+    if ("any" in condition) return condition.any.some((c) => evaluateTestCondition(c, resolveField));
+    if ("not" in condition) return !evaluateTestCondition(condition.not, resolveField);
+    if ("exists" in condition || "count" in condition) {
+      throw new Error("this campaign's conditions never use a collection quantifier (S16.5)");
+    }
+    const actual = resolveField(condition.field);
+    switch (condition.operator) {
+      case "equals": return actual === condition.value;
+      case "not_equals": return actual !== condition.value;
+      case "less_than": return (actual as number) < (condition.value as number);
+      case "greater_than": return (actual as number) > (condition.value as number);
+      default:
+        throw new Error(`test evaluator: extend for operator "${condition.operator}"`);
+    }
+  }
+
+  function fieldOf(state: Record<string, unknown>, path: string): unknown {
+    return path.split(".").reduce<unknown>((current, segment) => {
+      if (current === null || typeof current !== "object") return undefined;
+      return (current as Record<string, unknown>)[segment];
+    }, state);
+  }
+
+  /**
+   * A minimal player-state fixture, seeded from the built campaign's own authored values
+   * (the scenario's real starting cash; a real job/employer id pair from `stableLifeSource
+   * .jobs`), not invented numbers.
+   *
+   * This is not a full `createGame()` session. `createGame` currently throws for this
+   * campaign — `initial.ts`'s `buildPlayer` indexes `backgrounds[0]!.id` unconditionally,
+   * and `stableLifeSource.backgrounds` is still empty (S22, "a player does not start from
+   * nowhere," is what authors it; that is outside this slice's `Touches`). Discovered while
+   * implementing S16.3, not fixed here per `AGENTS.md`'s "note a defect outside this slice,
+   * don't fix it."
+   */
+  function fixturePlayerState(overrides: { cashCents?: number; employed?: boolean }): Record<string, unknown> {
+    const scenario = stableLifeSource.scenarios.find((s) => s.id === STABLE_LIFE_SCENARIO_ID)!;
+    const job = stableLifeSource.jobs.find((j) => j.id === "job-dishwasher")!;
+    return {
+      player: {
+        career: {
+          currentEmployment: overrides.employed
+            ? {
+                jobId: job.id,
+                employerId: job.employerId,
+                startedWeek: 1,
+                performance: 50,
+                attendanceRatio: 100,
+                warnings: 0,
+                weeklyPayCents: job.compensation.baseWeeklyPayCents,
+                weeksAtCurrentPay: 0,
+              }
+            : undefined,
+        },
+        finances: {
+          cashCents: overrides.cashCents ?? scenario.startingCashCents,
+        },
+      },
+    };
+  }
+
+  it("evaluates a job-held condition and a cash condition against a built campaign's real state (S16.3)", () => {
+    // The scenario starts unemployed (§16.3) — the job condition is false at the real
+    // starting state, and true once the player holds a job.
+    const jobHeld = stableLifeSource.events.find((e) => e.id === "event-shift-schedule-cut")!;
+    const unemployed = fixturePlayerState({});
+    expect(fieldOf(unemployed, "player.career.currentEmployment")).toBeUndefined();
+    expect(evaluateTestCondition(jobHeld.conditions, (p) => fieldOf(unemployed, p))).toBe(false);
+
+    const employed = fixturePlayerState({ employed: true });
+    expect(evaluateTestCondition(jobHeld.conditions, (p) => fieldOf(employed, p))).toBe(true);
+
+    // The scenario starts at $200 (§16.3) — above the hardship-relief threshold of $50, so
+    // false at the real starting state, and true once cash is mutated below it.
+    const cashConditional = stableLifeSource.events.find((e) => e.id === "event-hardship-relief-payment")!;
+    const atStartingCash = fixturePlayerState({});
+    expect(fieldOf(atStartingCash, "player.finances.cashCents")).toBe(20_000);
+    expect(evaluateTestCondition(cashConditional.conditions, (p) => fieldOf(atStartingCash, p))).toBe(false);
+
+    const poor = fixturePlayerState({ cashCents: 1_000 });
+    expect(evaluateTestCondition(cashConditional.conditions, (p) => fieldOf(poor, p))).toBe(true);
+  });
+
+  it("names only event ids that exist, in every generatedEvents/scheduledEvents reference (S16.4)", () => {
+    const ids = new Set(events.map((e) => e.id));
+    for (const event of events) {
+      const outcomes = [
+        ...(event.automaticOutcome ? [event.automaticOutcome] : []),
+        ...(event.choices ?? []).flatMap((c) => c.outcomes.map((o) => o.outcome)),
+      ];
+      for (const outcome of outcomes) {
+        for (const generatedId of outcome.generatedEvents ?? []) {
+          expect(ids.has(generatedId), `${event.id} generates unknown event "${generatedId}"`).toBe(true);
+        }
+        for (const scheduled of outcome.scheduledEvents ?? []) {
+          expect(ids.has(scheduled.eventId), `${event.id} schedules unknown event "${scheduled.eventId}"`).toBe(
+            true,
+          );
+        }
+      }
+    }
+    // The one chain this slice authors actually exercises the check above.
+    expect(events.some((e) => e.id === "event-tax-penalty-assessment")).toBe(true);
+  });
+
+  it("builds and validates with events wired in", () => {
     const result = buildStableLifeCampaign();
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);

--- a/src/campaigns/stable-life.ts
+++ b/src/campaigns/stable-life.ts
@@ -9,20 +9,27 @@
  * nothing is copied from the engine's own `stable-life` regression fixture, which is
  * engine-owned and unpublished.
  *
- * What it deliberately does not yet carry: courses, items, events, NPCs, opportunities,
+ * What it deliberately does not yet carry: courses, items, NPCs, opportunities,
  * achievements, headlines, backgrounds and traits (jobs, employers and skills were added by
- * S15). Each remaining collection is its own authoring slice against §16.1's content
- * targets. They are present and empty rather than absent, because `SimulationCampaignSource`
- * requires all seventeen and an empty one is an honest statement that the content is
- * unwritten.
+ * S15; 15 of §16.1's 30 events were added by S16, the other 15 are S21). Each remaining
+ * collection is its own authoring slice against §16.1's content targets. They are present
+ * and empty rather than absent, because `SimulationCampaignSource` requires all seventeen
+ * and an empty one is an honest statement that the content is unwritten.
  *
- * **One completion requirement from §16.3 is not expressible today.** "Education:
- * certificate or better" needs a condition over `player.education.credentials`, which is a
- * collection; `kinds/simulation/conditions.ts` implements `field` and throws on
- * `collection`, documenting the gap as "not yet" rather than "never". The goal below
- * carries the five requirements that are scalar comparisons and omits that one. This is
- * recorded as an open item rather than worked around — a goal that silently drops a stated
- * completion requirement would be worse than one that visibly does not carry it.
+ * **Two completion/condition requirements are not expressible today, for the same reason.**
+ * §16.3's "Education: certificate or better" needs a condition over
+ * `player.education.credentials`, a collection; `kinds/simulation/conditions.ts` implements
+ * `field` and throws on `collection` (the engine's `ConditionResolver.collection`, and
+ * therefore every `exists`/`count` quantifier in `Condition`), documenting the gap as "not
+ * yet" rather than "never". The goal below carries the five requirements that are scalar
+ * comparisons and omits that one. §11.3 names the same quantifiers for events —
+ * "owns any item tagged formal_clothing", "any NPC with resentment above 50" — and two of
+ * the 15 events below would have used one (S16.5): `event-job-interview-invitation` would
+ * gate on a `count` over `player.career.pendingApplications`, and `event-car-breakdown`
+ * would gate on an `exists` over `player.inventory` for an owned vehicle. Both omit that
+ * condition and name the omission at the site, per CP10. Recorded as an open item rather
+ * than worked around — a condition that silently drops a stated requirement would be worse
+ * than one that visibly does not carry it.
  */
 
 import {
@@ -509,6 +516,487 @@ const employers: SimulationCampaignSource["employers"] = [
 ];
 
 /**
+ * §16.1's random events — 15 of the 30 targeted (the other 15 are S21), drawn only from the
+ * seven `03` §11.1 categories S16 scopes: employment, economy, purchases, crime,
+ * bureaucracy, transportation, business. Every category appears at least once (S16.1).
+ *
+ * §11.2 names ten event *types*, but `EventDefinition` (`content.ts`) has no dedicated type
+ * field — the closest fit already in the schema is `tags`, the same mechanism S15 used to
+ * carry a job's career path outside its own strict schema. Every event below carries exactly
+ * one type tag, kebab-cased from §11.2 (S16.2).
+ *
+ * `Modifier.target` is restricted at validation time to `player.needs.*`,
+ * `player.attributes.*`, `player.skills.*`, and `calendar.committedTimeUnits`
+ * (`validate.ts`'s `WRITABLE_TARGET_PREFIXES`) — every cash effect below is therefore a
+ * `Reward` of type `"money"`, never a `Modifier`, since `player.finances.cashCents` is not a
+ * writable Modifier target.
+ */
+const events: SimulationCampaignSource["events"] = [
+  // --- Employment ---------------------------------------------------------------------
+  {
+    id: "event-shift-schedule-cut",
+    category: "employment",
+    title: { key: "stable-life.event.shift-schedule-cut.title", text: "Shift Cut Short" },
+    description: {
+      key: "stable-life.event.shift-schedule-cut.description",
+      text: "The schedule changes and a shift disappears from under you. The rent does not follow suit.",
+    },
+    weight: 12,
+    // S16.3 — conditional on a job the player holds. Comparing the whole optional
+    // `currentEmployment` object against `value: undefined` (documented in
+    // `core/condition/types.ts`) reads it in one hop; walking to `.jobId` beyond it would
+    // throw on an unemployed player, per `conditions.ts`'s generic per-segment walk.
+    conditions: { field: "player.career.currentEmployment", operator: "not_equals", value: undefined },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.stress", operation: "add", value: 6, sourceId: "event-shift-schedule-cut" },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(40) }],
+      messages: [
+        { key: "stable-life.event.shift-schedule-cut.outcome.message", visible: true, tone: "negative" },
+      ],
+    },
+    tags: ["conditional"],
+  },
+  {
+    id: "event-surprise-bonus",
+    category: "employment",
+    title: { key: "stable-life.event.surprise-bonus.title", text: "Surprise Bonus" },
+    description: {
+      key: "stable-life.event.surprise-bonus.description",
+      text: "The till balanced for once, and some of the difference lands in your pay.",
+    },
+    weight: 6,
+    // S16.3 — the second example of the job-held condition (S16.3 only requires one; this
+    // is a second, unforced instance).
+    conditions: { field: "player.career.currentEmployment", operator: "not_equals", value: undefined },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.happiness", operation: "add", value: 8, sourceId: "event-surprise-bonus" },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: DOLLARS(50) }],
+      messages: [{ key: "stable-life.event.surprise-bonus.outcome.message", visible: true, tone: "positive" }],
+    },
+    tags: ["conditional"],
+  },
+  {
+    id: "event-job-interview-invitation",
+    category: "employment",
+    title: { key: "stable-life.event.job-interview-invitation.title", text: "Interview Invitation" },
+    description: {
+      key: "stable-life.event.job-interview-invitation.description",
+      text: "Someone read the application after all, and wants to meet the person who wrote it.",
+    },
+    weight: 10,
+    // S16.5 — `03` §11.3 would gate this on a `count` over `player.career.pendingApplications`
+    // (has the player actually applied anywhere?). `count`/`exists` throw in this pinned
+    // engine (`conditions.ts`'s `unresolvableCollection`), so that quantifier is omitted;
+    // the condition narrows to "currently unemployed" only, which is a strictly weaker gate
+    // than the corpus intends. Named here rather than worked around, per CP10.
+    conditions: { field: "player.career.currentEmployment", operator: "equals", value: undefined },
+    choices: [
+      {
+        id: "attend-interview",
+        labelKey: "stable-life.event.job-interview-invitation.choice.attend-interview",
+        timeCost: 3,
+        outcomes: [
+          {
+            outcome: {
+              effects: [
+                {
+                  target: "player.needs.stress",
+                  operation: "add",
+                  value: 5,
+                  sourceId: "event-job-interview-invitation",
+                },
+              ],
+              rewards: [],
+              messages: [
+                {
+                  key: "stable-life.event.job-interview-invitation.outcome.attended",
+                  visible: true,
+                  tone: "neutral",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "skip-interview",
+        labelKey: "stable-life.event.job-interview-invitation.choice.skip-interview",
+        outcomes: [
+          {
+            outcome: {
+              effects: [],
+              rewards: [],
+              messages: [
+                {
+                  key: "stable-life.event.job-interview-invitation.outcome.skipped",
+                  visible: true,
+                  tone: "neutral",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+    tags: ["conditional"],
+  },
+
+  // --- Economy -------------------------------------------------------------------------
+  {
+    id: "event-inflation-adjustment",
+    category: "economy",
+    title: { key: "stable-life.event.inflation-adjustment.title", text: "Prices Creep Up" },
+    description: {
+      key: "stable-life.event.inflation-adjustment.description",
+      text: "Nothing on the shelf changed except the number under it.",
+    },
+    weight: 15,
+    conditions: { all: [] },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.stress", operation: "add", value: 3, sourceId: "event-inflation-adjustment" },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(15) }],
+      messages: [
+        { key: "stable-life.event.inflation-adjustment.outcome.message", visible: true, tone: "negative" },
+      ],
+    },
+    tags: ["world-triggered"],
+  },
+  {
+    id: "event-hardship-relief-payment",
+    category: "economy",
+    title: { key: "stable-life.event.hardship-relief-payment.title", text: "Hardship Relief Payment" },
+    description: {
+      key: "stable-life.event.hardship-relief-payment.description",
+      text: "A form filed months ago is finally worth something.",
+    },
+    weight: 5,
+    unique: true,
+    // S16.3 — conditional on the player's cash.
+    conditions: { field: "player.finances.cashCents", operator: "less_than", value: DOLLARS(50) },
+    automaticOutcome: {
+      effects: [
+        {
+          target: "player.needs.happiness",
+          operation: "add",
+          value: 5,
+          sourceId: "event-hardship-relief-payment",
+        },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: DOLLARS(80) }],
+      messages: [
+        { key: "stable-life.event.hardship-relief-payment.outcome.message", visible: true, tone: "positive" },
+      ],
+    },
+    tags: ["unique"],
+  },
+
+  // --- Purchases -----------------------------------------------------------------------
+  {
+    id: "event-appliance-breaks",
+    category: "purchases",
+    title: { key: "stable-life.event.appliance-breaks.title", text: "The Fridge Dies" },
+    description: {
+      key: "stable-life.event.appliance-breaks.description",
+      text: "It gives one last hum and stops. Everything in it has opinions about that now.",
+    },
+    weight: 10,
+    conditions: { all: [] },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.stress", operation: "add", value: 4, sourceId: "event-appliance-breaks" },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(35) }],
+      messages: [{ key: "stable-life.event.appliance-breaks.outcome.message", visible: true, tone: "negative" }],
+    },
+    tags: ["immediate"],
+  },
+  {
+    id: "event-limited-time-sale",
+    category: "purchases",
+    title: { key: "stable-life.event.limited-time-sale.title", text: "Limited-Time Sale" },
+    description: {
+      key: "stable-life.event.limited-time-sale.description",
+      text: "A sign in the window insists this will never happen again. It happened last month too.",
+    },
+    weight: 8,
+    conditions: { all: [] },
+    choices: [
+      {
+        id: "buy-now",
+        labelKey: "stable-life.event.limited-time-sale.choice.buy-now",
+        moneyCostCents: DOLLARS(20),
+        outcomes: [
+          {
+            outcome: {
+              effects: [
+                {
+                  target: "player.needs.happiness",
+                  operation: "add",
+                  value: 4,
+                  sourceId: "event-limited-time-sale",
+                },
+              ],
+              rewards: [],
+              messages: [
+                { key: "stable-life.event.limited-time-sale.outcome.bought", visible: true, tone: "positive" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "skip-sale",
+        labelKey: "stable-life.event.limited-time-sale.choice.skip-sale",
+        outcomes: [
+          {
+            outcome: {
+              effects: [],
+              rewards: [],
+              messages: [
+                { key: "stable-life.event.limited-time-sale.outcome.skipped", visible: true, tone: "neutral" },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+    tags: ["repeatable"],
+  },
+
+  // --- Crime ---------------------------------------------------------------------------
+  {
+    id: "event-pickpocketed",
+    category: "crime",
+    title: { key: "stable-life.event.pickpocketed.title", text: "Pickpocketed" },
+    description: {
+      key: "stable-life.event.pickpocketed.description",
+      text: "A crowd, a jostle, and a lighter pocket than you started the day with.",
+    },
+    weight: 6,
+    // S16.3 — a second, distinct example of a cash-conditional event (S16.3 only requires
+    // one; this one gates on cash being present at all rather than below a threshold).
+    conditions: { field: "player.finances.cashCents", operator: "greater_than", value: 0 },
+    automaticOutcome: {
+      effects: [{ target: "player.needs.stress", operation: "add", value: 8, sourceId: "event-pickpocketed" }],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(20) }],
+      messages: [{ key: "stable-life.event.pickpocketed.outcome.message", visible: true, tone: "negative" }],
+    },
+    tags: ["conditional"],
+  },
+  {
+    id: "event-mugging-attempt",
+    category: "crime",
+    title: { key: "stable-life.event.mugging-attempt.title", text: "Mugging Attempt" },
+    description: {
+      key: "stable-life.event.mugging-attempt.description",
+      text: "Someone blocks the alley shortcut and asks, not very politely, for your wallet.",
+    },
+    weight: 4,
+    conditions: { all: [] },
+    choices: [
+      {
+        id: "hand-over-wallet",
+        labelKey: "stable-life.event.mugging-attempt.choice.hand-over-wallet",
+        outcomes: [
+          {
+            outcome: {
+              effects: [
+                { target: "player.needs.stress", operation: "add", value: 10, sourceId: "event-mugging-attempt" },
+              ],
+              rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(30) }],
+              messages: [
+                {
+                  key: "stable-life.event.mugging-attempt.outcome.handed-over",
+                  visible: true,
+                  tone: "negative",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "run-away",
+        labelKey: "stable-life.event.mugging-attempt.choice.run-away",
+        outcomes: [
+          {
+            outcome: {
+              effects: [
+                { target: "player.needs.stress", operation: "add", value: 6, sourceId: "event-mugging-attempt" },
+                { target: "player.needs.energy", operation: "subtract", value: 5, sourceId: "event-mugging-attempt" },
+              ],
+              rewards: [],
+              messages: [
+                { key: "stable-life.event.mugging-attempt.outcome.ran-away", visible: true, tone: "neutral" },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+    tags: ["world-triggered"],
+  },
+
+  // --- Bureaucracy — a two-step chain (03 §11.6) ----------------------------------------
+  {
+    id: "event-late-tax-filing-notice",
+    category: "bureaucracy",
+    title: { key: "stable-life.event.late-tax-filing-notice.title", text: "Late Filing Notice" },
+    description: {
+      key: "stable-life.event.late-tax-filing-notice.description",
+      text: "A form due last season is due again, this time with a tone.",
+    },
+    weight: 7,
+    conditions: { all: [] },
+    chainId: "tax-filing-chain",
+    chainStep: 1,
+    automaticOutcome: {
+      effects: [
+        {
+          target: "player.needs.stress",
+          operation: "add",
+          value: 5,
+          sourceId: "event-late-tax-filing-notice",
+        },
+      ],
+      rewards: [],
+      messages: [
+        { key: "stable-life.event.late-tax-filing-notice.outcome.message", visible: true, tone: "negative" },
+      ],
+      // S16.4 — the id below must name a real event in this same collection.
+      scheduledEvents: [{ eventId: "event-tax-penalty-assessment", inWeeks: 2 }],
+    },
+    tags: ["chained"],
+  },
+  {
+    id: "event-tax-penalty-assessment",
+    category: "bureaucracy",
+    title: { key: "stable-life.event.tax-penalty-assessment.title", text: "Penalty Assessment" },
+    description: {
+      key: "stable-life.event.tax-penalty-assessment.description",
+      text: "The tone from two weeks ago becomes a number.",
+    },
+    // `weight: 0` — reachable only via the `scheduledEvents` link above, never by random
+    // draw. `endOfWeek.ts`'s own `drawable()` comment names this as the intended way to
+    // author a schedule-only event; scheduled firing also ignores `conditions` entirely
+    // (same file), so the trivial condition below is never actually evaluated for this one.
+    weight: 0,
+    conditions: { all: [] },
+    chainId: "tax-filing-chain",
+    chainStep: 2,
+    automaticOutcome: {
+      effects: [],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(45) }],
+      messages: [
+        { key: "stable-life.event.tax-penalty-assessment.outcome.message", visible: true, tone: "negative" },
+      ],
+      endsChain: true,
+    },
+    tags: ["chained"],
+  },
+
+  // --- Transportation --------------------------------------------------------------------
+  {
+    id: "event-bus-fare-increase",
+    category: "transportation",
+    title: { key: "stable-life.event.bus-fare-increase.title", text: "Fare Goes Up Again" },
+    description: {
+      key: "stable-life.event.bus-fare-increase.description",
+      text: "The board votes on a Tuesday no one attends. The fare box votes every day after.",
+    },
+    weight: 12,
+    cooldownWeeks: 8,
+    conditions: { all: [] },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.stress", operation: "add", value: 2, sourceId: "event-bus-fare-increase" },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(5) }],
+      messages: [{ key: "stable-life.event.bus-fare-increase.outcome.message", visible: true, tone: "negative" }],
+    },
+    tags: ["recurring"],
+  },
+  {
+    id: "event-car-breakdown",
+    category: "transportation",
+    title: { key: "stable-life.event.car-breakdown.title", text: "Car Breakdown" },
+    description: {
+      key: "stable-life.event.car-breakdown.description",
+      text: "Something under the hood decides today is the day.",
+    },
+    weight: 3,
+    // S16.5 — `03` §11.3 would gate this on an `exists` over `player.inventory` for an
+    // owned vehicle ("owns any item tagged formal_clothing" is the corpus's own worked
+    // example of exactly this shape). `exists`/`count` throw in this pinned engine, and
+    // `items` is unauthored this slice regardless, so the ownership check is omitted
+    // entirely rather than approximated; the event fires as ambient background instead.
+    // Named here per CP10.
+    conditions: { all: [] },
+    automaticOutcome: {
+      effects: [{ target: "player.needs.stress", operation: "add", value: 7, sourceId: "event-car-breakdown" }],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: -DOLLARS(60) }],
+      messages: [{ key: "stable-life.event.car-breakdown.outcome.message", visible: true, tone: "negative" }],
+    },
+    tags: ["world-triggered"],
+  },
+
+  // --- Business ----------------------------------------------------------------------
+  {
+    id: "event-team-morale-day",
+    category: "business",
+    title: { key: "stable-life.event.team-morale-day.title", text: "Team Morale Day" },
+    description: {
+      key: "stable-life.event.team-morale-day.description",
+      text: "Someone brought a cake. It is being treated as a major event.",
+    },
+    weight: 9,
+    conditions: { all: [] },
+    automaticOutcome: {
+      effects: [
+        { target: "player.needs.happiness", operation: "add", value: 6, sourceId: "event-team-morale-day" },
+      ],
+      rewards: [],
+      messages: [{ key: "stable-life.event.team-morale-day.outcome.message", visible: true, tone: "positive" }],
+    },
+    tags: ["world-triggered"],
+  },
+  {
+    id: "event-employee-of-the-month",
+    category: "business",
+    title: { key: "stable-life.event.employee-of-the-month.title", text: "Employee of the Month" },
+    description: {
+      key: "stable-life.event.employee-of-the-month.description",
+      text: "A laminated certificate and a small cash bonus, in that order of perceived value.",
+    },
+    weight: 4,
+    unique: true,
+    // S16.3 — a third example of the job-held condition.
+    conditions: { field: "player.career.currentEmployment", operator: "not_equals", value: undefined },
+    automaticOutcome: {
+      effects: [
+        {
+          target: "player.needs.happiness",
+          operation: "add",
+          value: 10,
+          sourceId: "event-employee-of-the-month",
+        },
+      ],
+      rewards: [{ type: "money", target: "player.finances.cashCents", value: DOLLARS(100) }],
+      messages: [
+        { key: "stable-life.event.employee-of-the-month.outcome.message", visible: true, tone: "positive" },
+      ],
+    },
+    tags: ["unique"],
+  },
+];
+
+/**
  * §16.3's completion requirements, minus the credential one the condition language cannot
  * express yet (see the file header). `highestTierAchieved` is a string, so "skilled or
  * better" is authored as the explicit set rather than an ordering comparison — the tier
@@ -586,7 +1074,7 @@ export const stableLifeSource: SimulationCampaignSource = {
   courses: [],
   housing,
   items: [],
-  events: [],
+  events,
   npcs: [],
   goals,
   scenarios,
@@ -623,7 +1111,7 @@ const CAMPAIGN_TITLE = {
 /**
  * The catalog card that travels with the published campaign. `contentNotice` says plainly
  * that this is a seed — a player reaching it from a catalog should not be told it is the
- * game when fourteen of its seventeen content collections are empty.
+ * game when eight of its seventeen content collections are empty.
  */
 export const stableLifeCatalog = {
   title: "Life in the Fast Lane — Stable Life",
@@ -631,7 +1119,7 @@ export const stableLifeCatalog = {
     "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
   duration: "52 weeks",
   contentNotice:
-    "Seed content. The map, the scenario and the career ladder are authored; courses, events and possessions are not yet written.",
+    "Seed content. The map, the scenario, the career ladder and 15 of 30 random events are authored; courses and possessions are not yet written.",
   featured: false,
   hidden: true,
 } as const;


### PR DESCRIPTION
## Summary

Authors 15 of §16.1's 30 random events (the other 15 are S21), drawn only from the seven §11.1 categories this slice scopes: employment, economy, purchases, crime, bureaucracy, transportation, business — every one represented at least once.

Closes #84

- **Employment**: `event-shift-schedule-cut`, `event-surprise-bonus` (both job-conditional), `event-job-interview-invitation`
- **Economy**: `event-inflation-adjustment`, `event-hardship-relief-payment` (cash-conditional, unique)
- **Purchases**: `event-appliance-breaks`, `event-limited-time-sale`
- **Crime**: `event-pickpocketed` (cash-conditional), `event-mugging-attempt`
- **Bureaucracy**: `event-late-tax-filing-notice` → `event-tax-penalty-assessment` — a two-step chain (§11.6), the second event `weight: 0` (schedule-only, per `endOfWeek.ts`'s own documented convention)
- **Transportation**: `event-bus-fare-increase` (recurring, `cooldownWeeks`), `event-car-breakdown`
- **Business**: `event-team-morale-day`, `event-employee-of-the-month` (job-conditional, unique)

`EventDefinition` has no dedicated "type" field for §11.2's ten event types, so each event carries exactly one kebab-cased type value in `tags` — the same mechanism S15 used for a job's career path. `Modifier.target` is validation-restricted to `player.needs.*`/`player.attributes.*`/`player.skills.*`/`calendar.committedTimeUnits`, so every cash effect is a `Reward` of type `"money"` rather than a `Modifier`.

## Acceptance criteria (S16)

- [x] S16.1 — 15 entries, all seven scoped categories represented at least once
- [x] S16.2 — every event names its category and its type (via `tags`), both asserted against the corpus's closed lists
- [x] S16.3 — at least one event conditional on a held job, at least one on cash — evaluated with a local mirror of the engine's own `Condition` evaluator against a fixture seeded from the built campaign's real starting values (see note below on why not a live `createGame()` session)
- [x] S16.4 — every `generatedEvents`/`scheduledEvents` reference names a real event id, asserted by iterating the collection
- [x] S16.5 — `03` §11.3's collection quantifiers (`exists`/`count`) aren't expressible by the pinned engine (`kinds/simulation/conditions.ts` throws on `collection`). 2 of the 15 events would have used one and omit it instead, named at the site: `event-job-interview-invitation` (would gate on a `count` over `player.career.pendingApplications`) and `event-car-breakdown` (would gate on an `exists` over `player.inventory`). Logged under `design/90-decisions.md` § Open.
- [x] S16.6 — `npm run check` passes; `content/` regenerated in this commit

## Descriptive correction

Two stale inline facts in `stable-life.ts`, corrected in this commit: the file-header collection list still named `events` as unwritten (now events are 15/30 authored), and the catalog card's `contentNotice`/comment said "fourteen of its seventeen content collections are empty" — actually eight, both before and after this slice's own change to the count.

## Discovered, not fixed (outside `Touches`)

`createEngine().createGame(...)` throws for this campaign: `kinds/simulation/initial.ts`'s `buildPlayer` indexes `backgrounds[0]!.id` unconditionally, and `stableLifeSource.backgrounds` is still empty. No game session can be created until S22 ("a player does not start from nowhere") authors at least one background. This is why S16.3's test evaluates the real authored `Condition` objects against a fixture built from the campaign's own starting values rather than a live engine session. Logged under `design/90-decisions.md` § Open.

## Out of scope (per the slice)

The other 15 events (S21); events requiring an NPC (S20); any widening of the engine's condition language (the engine repository's).

## Verified

Ran and passed:
- Parse-check PowerShell scripts — all 73 `*.ps1` files parsed with `System.Management.Automation.Language.Parser`, zero parse errors
- Run Pester tests — `Invoke-Pester -Path tools -Output Detailed -PassThru`: 350 passed, 0 failed, 0 skipped, 188.62s
- Validate the core/companion split — `./tools/Test-Companion.ps1`: 23 core(s) checked, 0 companions, State: Valid, exit 0
- Check the design state against the tree — `./tools/Test-DesignState.ps1`: Findings (0); Reported (26), all `MirrorStale` on `design/state/work/*.md` and non-blocking (this branch hasn't run `/track` yet); Could not evaluate (0); exit 0
- Check the spec set — `./tools/Test-SpecSet.ps1`: Valid; 8 documents; 936 declarations; 2 mirror obligations checked; 8 references unresolvable (cross-repository, not checked); WorkingTree Clean; exit 0
- Build the pinned engine — `npm run setup`: `npm ci` (140 packages) + `npm run build` (clean + `tsc -p tsconfig.build.json`), exit 0
- Typecheck the campaign sources — `npm run typecheck`: `tsc --noEmit`, no output, exit 0
- Test the campaign sources — `npm test`: vitest — 4 files passed, 29/29 tests passed, exit 0 (includes the 5 new S16 tests, each verified to fail before the events/evaluator existed)
- Re-export content and fail if the committed JSON is stale — `npm run export:content` ("Exported 1 campaign(s) to content/") then `npm run check:clean` ("content/ matches the sources."), both exit 0; `git status --short` reported nothing under `content/` afterward

Ran and failed: none.

Did not run: none — all 9 `# verification: true`-flagged CI steps ran locally and are accounted for above. `git diff --check` and `git status --short --branch` (not CI-flagged, standard housekeeping) were also run and are clean.

Structured report: `.claude/verify-report.json`, validated by `tools/Test-VerifyReport.ps1` — `Valid`, 9 gates, 0 findings, 0 could-not-evaluate.

CI itself has not yet reported on this exact push — its outcome will be checked separately rather than assumed here.
