### PR TITLE
S17 — Education is something a player can actually buy, attend, and fail

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -5,7 +5,7 @@
       "file": "stable-life.json",
       "id": "life-in-the-fast-lane-stable-life",
       "version": "0.1.0",
-      "digest": "sha-256:f22f174bf9ff5f1f427269b37cbc7248f26803595031fbe447f7553e9dd82a06"
+      "digest": "sha-256:db7129cbc739a1f75cf8ba0140aef1f4de63d61dac1dc29128e52f0e33d5a58b"
     }
   ],
   "resolution": "sha-256:69d83e73ed1b957f9f09ff86d146b21f928b91748108f76b806f403b0ae112d4"

--- a/content/stable-life.json
+++ b/content/stable-life.json
@@ -4,7 +4,7 @@
     "title": "Life in the Fast Lane — Stable Life",
     "description": "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
     "duration": "52 weeks",
-    "contentNotice": "Seed content. The map, the scenario, the career ladder and 15 of 30 random events are authored; courses and possessions are not yet written.",
+    "contentNotice": "Seed content. The map, the scenario, the career ladder, 6 courses and 15 of 30 random events are authored; possessions are not yet written.",
     "featured": false,
     "hidden": true
   },
@@ -347,7 +347,183 @@
           "descriptionKey": "stable-life.job.retail-associate.description"
         }
       ],
-      "courses": [],
+      "courses": [
+        {
+          "id": "course-high-school-equivalency",
+          "providerId": "provider-community-college",
+          "tuitionCents": 34000,
+          "durationWeeks": 8,
+          "weeklyTimeCost": 3,
+          "difficulty": 25,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "attribute",
+              "target": "player.attributes.intelligence",
+              "value": 5
+            }
+          ],
+          "awardsCredential": "school",
+          "failureRules": {
+            "minimumAttendanceRatio": 70,
+            "minimumStudyUnitsPerWeek": 1,
+            "maximumMissedSessions": 3,
+            "tuitionGraceWeeks": 1,
+            "progressRetainedOnFailure": 40
+          },
+          "tags": [
+            "high-school-equivalency"
+          ],
+          "nameKey": "stable-life.course.high-school-equivalency.name",
+          "descriptionKey": "stable-life.course.high-school-equivalency.description"
+        },
+        {
+          "id": "course-night-class-supervision",
+          "providerId": "provider-community-college",
+          "tuitionCents": 34000,
+          "durationWeeks": 8,
+          "weeklyTimeCost": 3,
+          "difficulty": 20,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "skill",
+              "target": "player.skills.management",
+              "value": 10
+            }
+          ],
+          "failureRules": {
+            "minimumAttendanceRatio": 70,
+            "minimumStudyUnitsPerWeek": 1,
+            "maximumMissedSessions": 3,
+            "tuitionGraceWeeks": 1,
+            "progressRetainedOnFailure": 40
+          },
+          "tags": [
+            "night-classes"
+          ],
+          "nameKey": "stable-life.course.night-class-supervision.name",
+          "descriptionKey": "stable-life.course.night-class-supervision.description"
+        },
+        {
+          "id": "course-vocational-certificate-culinary",
+          "providerId": "provider-community-college",
+          "tuitionCents": 90000,
+          "durationWeeks": 16,
+          "weeklyTimeCost": 4,
+          "difficulty": 45,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "skill",
+              "target": "player.skills.cooking",
+              "value": 20
+            }
+          ],
+          "awardsCredential": "certificate",
+          "failureRules": {
+            "minimumAttendanceRatio": 75,
+            "minimumStudyUnitsPerWeek": 2,
+            "maximumMissedSessions": 4,
+            "tuitionGraceWeeks": 2,
+            "maximumStress": 80,
+            "progressRetainedOnFailure": 50
+          },
+          "tags": [
+            "vocational-certificates"
+          ],
+          "nameKey": "stable-life.course.vocational-certificate-culinary.name",
+          "descriptionKey": "stable-life.course.vocational-certificate-culinary.description"
+        },
+        {
+          "id": "course-professional-certification-it",
+          "providerId": "provider-professional-institute",
+          "tuitionCents": 90000,
+          "durationWeeks": 16,
+          "weeklyTimeCost": 4,
+          "difficulty": 50,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "skill",
+              "target": "player.skills.programming",
+              "value": 20
+            }
+          ],
+          "awardsCredential": "certificate",
+          "failureRules": {
+            "minimumAttendanceRatio": 75,
+            "minimumStudyUnitsPerWeek": 2,
+            "maximumMissedSessions": 4,
+            "tuitionGraceWeeks": 2,
+            "maximumStress": 80,
+            "progressRetainedOnFailure": 50
+          },
+          "tags": [
+            "professional-certifications"
+          ],
+          "nameKey": "stable-life.course.professional-certification-it.name",
+          "descriptionKey": "stable-life.course.professional-certification-it.description"
+        },
+        {
+          "id": "course-university-degree-module-management",
+          "providerId": "provider-state-university",
+          "tuitionCents": 160000,
+          "durationWeeks": 24,
+          "weeklyTimeCost": 5,
+          "difficulty": 65,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "skill",
+              "target": "player.skills.management",
+              "value": 30
+            }
+          ],
+          "awardsCredential": "degree",
+          "failureRules": {
+            "minimumAttendanceRatio": 80,
+            "minimumStudyUnitsPerWeek": 3,
+            "maximumMissedSessions": 5,
+            "tuitionGraceWeeks": 3,
+            "maximumStress": 85,
+            "progressRetainedOnFailure": 55
+          },
+          "tags": [
+            "university-degrees"
+          ],
+          "nameKey": "stable-life.course.university-degree-module-management.name",
+          "descriptionKey": "stable-life.course.university-degree-module-management.description"
+        },
+        {
+          "id": "course-questionable-motivational-seminar",
+          "providerId": "provider-peak-potential-seminars",
+          "tuitionCents": 160000,
+          "durationWeeks": 24,
+          "weeklyTimeCost": 5,
+          "difficulty": 10,
+          "requirements": [],
+          "rewards": [
+            {
+              "type": "attribute",
+              "target": "player.attributes.charisma",
+              "value": 5
+            }
+          ],
+          "failureRules": {
+            "minimumAttendanceRatio": 50,
+            "minimumStudyUnitsPerWeek": 1,
+            "maximumMissedSessions": 8,
+            "tuitionGraceWeeks": 0,
+            "progressRetainedOnFailure": 20
+          },
+          "tags": [
+            "questionable-motivational-seminars"
+          ],
+          "nameKey": "stable-life.course.questionable-motivational-seminar.name",
+          "descriptionKey": "stable-life.course.questionable-motivational-seminar.description"
+        }
+      ],
       "housing": [
         {
           "id": "housing-rented-room",
@@ -1310,6 +1486,18 @@
     "stable-life.action.plan-remove": "Unplan",
     "stable-life.campaign.description": "Life in the Fast Lane — the Stable Life scenario. Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
     "stable-life.campaign.title": "Life in the Fast Lane — Stable Life",
+    "stable-life.course.high-school-equivalency.description": "Eight weeks to a piece of paper the last one should have already provided.",
+    "stable-life.course.high-school-equivalency.name": "High-School Equivalency",
+    "stable-life.course.night-class-supervision.description": "Two evenings a week, a whiteboard, and the beginnings of telling other people what to do.",
+    "stable-life.course.night-class-supervision.name": "Night Class: Basic Supervision",
+    "stable-life.course.professional-certification-it.description": "Sixteen weeks, a proctored exam, and a certificate suitable for framing or for nothing.",
+    "stable-life.course.professional-certification-it.name": "Professional Certification: Entry IT",
+    "stable-life.course.questionable-motivational-seminar.description": "Nobody has ever explained what week nine covers. Week nine attendees have stopped asking.",
+    "stable-life.course.questionable-motivational-seminar.name": "Peak Potential: A Twenty-Four-Week Journey",
+    "stable-life.course.university-degree-module-management.description": "Twenty-four weeks, one module of a longer degree, and the most expensive line item this scenario offers.",
+    "stable-life.course.university-degree-module-management.name": "University Degree Module: Management",
+    "stable-life.course.vocational-certificate-culinary.description": "Sixteen weeks of a working kitchen, minus the part where anyone pays you for it yet.",
+    "stable-life.course.vocational-certificate-culinary.name": "Vocational Certificate: Culinary Trade",
     "stable-life.difficulty.standard.label": "Standard",
     "stable-life.employer.bright-mart-retail.name": "BrightMart Retail",
     "stable-life.employer.civic-data-office.name": "Civic Data Office",

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -94,10 +94,10 @@ describe("Stable Life — the authoring path", () => {
   });
 
   it("names every collection the source requires, so an unwritten one is visibly empty", () => {
-    // §16.1's jobs/employers/skills targets are now authored (S15), and 15 of 30 events
-    // (S16); the rest are still an honest statement that the content is unwritten.
+    // §16.1's jobs/employers/skills targets are now authored (S15), 15 of 30 events (S16),
+    // and courses (S17); the rest are still an honest statement that the content is unwritten.
     const empty = [
-      "courses", "items", "npcs", "opportunities", "achievements",
+      "items", "npcs", "opportunities", "achievements",
       "headlines", "backgrounds", "traits",
     ] as const;
     for (const key of empty) {
@@ -337,6 +337,107 @@ describe("Stable Life — random events (S16)", () => {
   });
 
   it("builds and validates with events wired in", () => {
+    const result = buildStableLifeCampaign();
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    const registry = buildValidatedContentRegistry([built()], kinds);
+    expect(registry.errors).toEqual([]);
+    expect(registry.ok).toBe(true);
+  });
+});
+
+describe("Stable Life — courses (S17)", () => {
+  const courses = stableLifeSource.courses;
+
+  // `03` §7.1's ten education types, kebab-cased verbatim from the corpus's own list.
+  // `CourseDefinition` (content.ts) has no dedicated type field — the same `tags` mechanism
+  // S16.2 used for event types carries it here.
+  const VALID_EDUCATION_TYPES = new Set([
+    "high-school-equivalency", "vocational-certificates", "university-degrees",
+    "night-classes", "professional-certifications", "online-courses",
+    "self-directed-learning", "apprenticeships", "employer-training",
+    "questionable-motivational-seminars",
+  ]);
+
+  // `03` §16.4's education-cost table, restated as literal cent/unit values rather than read
+  // from the source's own constant — the same independence S15.4's wage-table test used.
+  const EDUCATION_COST_TABLE = [
+    { tuitionCents: 34_000, durationWeeks: 8, weeklyTimeCost: 3 }, // Short certificate
+    { tuitionCents: 90_000, durationWeeks: 16, weeklyTimeCost: 4 }, // Vocational certificate
+    { tuitionCents: 160_000, durationWeeks: 24, weeklyTimeCost: 5 }, // Degree module
+  ] as const;
+
+  function educationTypeOf(course: (typeof courses)[number]): string {
+    const typeTags = course.tags.filter((t) => VALID_EDUCATION_TYPES.has(t));
+    expect(typeTags, `${course.id} should carry exactly one §7.1 type tag`).toHaveLength(1);
+    return typeTags[0]!;
+  }
+
+  it("has 6 entries, each a distinct §7.1 education type (S17.1)", () => {
+    expect(courses).toHaveLength(6);
+    const types = courses.map(educationTypeOf);
+    expect(new Set(types).size, "every course should use a different §7.1 type").toBe(6);
+    for (const type of types) {
+      expect(VALID_EDUCATION_TYPES.has(type), `"${type}" should be one of §7.1's types`).toBe(true);
+    }
+  });
+
+  it("prices tuition, duration and weekly time cost from §16.4's education-cost table exactly (S17.2)", () => {
+    for (const course of courses) {
+      const matches = EDUCATION_COST_TABLE.some(
+        (row) =>
+          row.tuitionCents === course.tuitionCents &&
+          row.durationWeeks === course.durationWeeks &&
+          row.weeklyTimeCost === course.weeklyTimeCost,
+      );
+      expect(matches, `${course.id}'s tuition/duration/weeklyTimeCost should match a §16.4 row exactly`).toBe(
+        true,
+      );
+    }
+    // All three rows are actually used, not just one stretched across all six.
+    for (const row of EDUCATION_COST_TABLE) {
+      const used = courses.some(
+        (c) =>
+          c.tuitionCents === row.tuitionCents &&
+          c.durationWeeks === row.durationWeeks &&
+          c.weeklyTimeCost === row.weeklyTimeCost,
+      );
+      expect(used, `no course prices from the $${row.tuitionCents / 100} row`).toBe(true);
+    }
+  });
+
+  it("carries §7.4's failure rules — attendance floor, study floor, retained progress — within range (S17.3)", () => {
+    for (const course of courses) {
+      const rules = course.failureRules;
+      expect(rules, `${course.id} should carry failureRules`).toBeDefined();
+      expect(rules.minimumAttendanceRatio, `${course.id}'s attendance floor`).toBeGreaterThan(0);
+      expect(rules.minimumAttendanceRatio, `${course.id}'s attendance floor`).toBeLessThanOrEqual(100);
+      expect(rules.minimumStudyUnitsPerWeek, `${course.id}'s study floor`).toBeGreaterThan(0);
+      expect(rules.progressRetainedOnFailure, `${course.id}'s retained progress`).toBeGreaterThanOrEqual(0);
+      expect(rules.progressRetainedOnFailure, `${course.id}'s retained progress`).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("names only credentials a course actually grants, checked against every job requirement (S17.4)", () => {
+    const grantedLevels = new Set(
+      courses.map((c) => c.awardsCredential).filter((level): level is NonNullable<typeof level> => level !== undefined),
+    );
+    const credentialRequirements = stableLifeSource.jobs
+      .flatMap((job) => job.requirements)
+      .filter((r) => r.type === "credential");
+    for (const requirement of credentialRequirements) {
+      if ("field" in requirement.condition) {
+        expect(
+          grantedLevels.has(
+            requirement.condition.value as NonNullable<(typeof courses)[number]["awardsCredential"]>,
+          ),
+          `a job requires credential "${requirement.condition.value}", which no course grants`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("builds and validates with courses wired in", () => {
     const result = buildStableLifeCampaign();
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);

--- a/src/campaigns/stable-life.ts
+++ b/src/campaigns/stable-life.ts
@@ -9,12 +9,13 @@
  * nothing is copied from the engine's own `stable-life` regression fixture, which is
  * engine-owned and unpublished.
  *
- * What it deliberately does not yet carry: courses, items, NPCs, opportunities,
- * achievements, headlines, backgrounds and traits (jobs, employers and skills were added by
- * S15; 15 of §16.1's 30 events were added by S16, the other 15 are S21). Each remaining
- * collection is its own authoring slice against §16.1's content targets. They are present
- * and empty rather than absent, because `SimulationCampaignSource` requires all seventeen
- * and an empty one is an honest statement that the content is unwritten.
+ * What it deliberately does not yet carry: items, NPCs, opportunities, achievements,
+ * headlines, backgrounds and traits (jobs, employers and skills were added by S15; 15 of
+ * §16.1's 30 events were added by S16; courses were added by S17, the other 15 events are
+ * S21). Each remaining collection is its own authoring slice against §16.1's content
+ * targets. They are present and empty rather than absent, because `SimulationCampaignSource`
+ * requires all seventeen and an empty one is an honest statement that the content is
+ * unwritten.
  *
  * **Two completion/condition requirements are not expressible today, for the same reason.**
  * §16.3's "Education: certificate or better" needs a condition over
@@ -218,6 +219,198 @@ const skills: SimulationCampaignSource["skills"] = [
     name: { key: "stable-life.skill.programming.name", text: "Programming" },
     category: "technical",
     decayPerWeek: 0,
+  },
+];
+
+/**
+ * §16.4's education-cost table, by duration tier. Cited once here rather than re-typed into
+ * each course, the same reason `WAGE_TABLE_CENTS` above exists — a rate change touches one
+ * place. `CourseDefinition` (content.ts) carries no tier field of its own; these three keys
+ * are local to this file and exist only to group the six courses onto the table's three rows.
+ */
+const EDUCATION_COST_TABLE: Record<
+  "short" | "vocational" | "degree",
+  { tuitionCents: number; durationWeeks: number; weeklyTimeCost: number }
+> = {
+  short: { tuitionCents: DOLLARS(340), durationWeeks: 8, weeklyTimeCost: 3 },
+  vocational: { tuitionCents: DOLLARS(900), durationWeeks: 16, weeklyTimeCost: 4 },
+  degree: { tuitionCents: DOLLARS(1600), durationWeeks: 24, weeklyTimeCost: 5 },
+};
+
+/**
+ * §7.1/§16.1 — the six courses, each a distinct §7.1 education type (carried as a tag, the
+ * same mechanism S16.2 used for event types — `CourseDefinition` has no dedicated type
+ * field). Every one prices from `EDUCATION_COST_TABLE` exactly (§16.4, S17.2); two courses
+ * share the vocational tier and two share the short tier, the same way S15's jobs shared a
+ * wage-table tier across career paths. `providerId` has no matching collection in
+ * `SimulationCampaignSource` — it is a free descriptive string, not a foreign key.
+ *
+ * Where a reward references a skill, it is one S15 already authored (`cooking`,
+ * `management`, `programming`) and its value is chosen to meaningfully close the gap toward
+ * that skill's job or promotion requirement — §7.3's "job eligibility" reward, made concrete.
+ */
+const courses: SimulationCampaignSource["courses"] = [
+  // §7.1 "High-school equivalency" — short tier.
+  {
+    id: "course-high-school-equivalency",
+    name: {
+      key: "stable-life.course.high-school-equivalency.name",
+      text: "High-School Equivalency",
+    },
+    description: {
+      key: "stable-life.course.high-school-equivalency.description",
+      text: "Eight weeks to a piece of paper the last one should have already provided.",
+    },
+    providerId: "provider-community-college",
+    ...EDUCATION_COST_TABLE.short,
+    difficulty: 25,
+    requirements: [],
+    rewards: [{ type: "attribute", target: "player.attributes.intelligence", value: 5 }],
+    awardsCredential: "school",
+    failureRules: {
+      minimumAttendanceRatio: 70,
+      minimumStudyUnitsPerWeek: 1,
+      maximumMissedSessions: 3,
+      tuitionGraceWeeks: 1,
+      progressRetainedOnFailure: 40,
+    },
+    tags: ["high-school-equivalency"],
+  },
+  // §7.1 "Night classes" — short tier.
+  {
+    id: "course-night-class-supervision",
+    name: {
+      key: "stable-life.course.night-class-supervision.name",
+      text: "Night Class: Basic Supervision",
+    },
+    description: {
+      key: "stable-life.course.night-class-supervision.description",
+      text: "Two evenings a week, a whiteboard, and the beginnings of telling other people what to do.",
+    },
+    providerId: "provider-community-college",
+    ...EDUCATION_COST_TABLE.short,
+    difficulty: 20,
+    requirements: [],
+    rewards: [{ type: "skill", target: "player.skills.management", value: 10 }],
+    failureRules: {
+      minimumAttendanceRatio: 70,
+      minimumStudyUnitsPerWeek: 1,
+      maximumMissedSessions: 3,
+      tuitionGraceWeeks: 1,
+      progressRetainedOnFailure: 40,
+    },
+    tags: ["night-classes"],
+  },
+  // §7.1 "Vocational certificates" — vocational tier. §6.2's cooking requirement for
+  // job-line-cook is the same field this course's reward moves.
+  {
+    id: "course-vocational-certificate-culinary",
+    name: {
+      key: "stable-life.course.vocational-certificate-culinary.name",
+      text: "Vocational Certificate: Culinary Trade",
+    },
+    description: {
+      key: "stable-life.course.vocational-certificate-culinary.description",
+      text: "Sixteen weeks of a working kitchen, minus the part where anyone pays you for it yet.",
+    },
+    providerId: "provider-community-college",
+    ...EDUCATION_COST_TABLE.vocational,
+    difficulty: 45,
+    requirements: [],
+    rewards: [{ type: "skill", target: "player.skills.cooking", value: 20 }],
+    awardsCredential: "certificate",
+    failureRules: {
+      minimumAttendanceRatio: 75,
+      minimumStudyUnitsPerWeek: 2,
+      maximumMissedSessions: 4,
+      tuitionGraceWeeks: 2,
+      maximumStress: 80,
+      progressRetainedOnFailure: 50,
+    },
+    tags: ["vocational-certificates"],
+  },
+  // §7.1 "Professional certifications" — vocational tier. §6.2's programming requirement
+  // for job-systems-administrator is the same field this course's reward moves.
+  {
+    id: "course-professional-certification-it",
+    name: {
+      key: "stable-life.course.professional-certification-it.name",
+      text: "Professional Certification: Entry IT",
+    },
+    description: {
+      key: "stable-life.course.professional-certification-it.description",
+      text: "Sixteen weeks, a proctored exam, and a certificate suitable for framing or for nothing.",
+    },
+    providerId: "provider-professional-institute",
+    ...EDUCATION_COST_TABLE.vocational,
+    difficulty: 50,
+    requirements: [],
+    rewards: [{ type: "skill", target: "player.skills.programming", value: 20 }],
+    awardsCredential: "certificate",
+    failureRules: {
+      minimumAttendanceRatio: 75,
+      minimumStudyUnitsPerWeek: 2,
+      maximumMissedSessions: 4,
+      tuitionGraceWeeks: 2,
+      maximumStress: 80,
+      progressRetainedOnFailure: 50,
+    },
+    tags: ["professional-certifications"],
+  },
+  // §7.1 "University degrees" — degree tier, authored as one module per §16.4's own naming
+  // ("Degree module"), not a full multi-year degree.
+  {
+    id: "course-university-degree-module-management",
+    name: {
+      key: "stable-life.course.university-degree-module-management.name",
+      text: "University Degree Module: Management",
+    },
+    description: {
+      key: "stable-life.course.university-degree-module-management.description",
+      text: "Twenty-four weeks, one module of a longer degree, and the most expensive line item this scenario offers.",
+    },
+    providerId: "provider-state-university",
+    ...EDUCATION_COST_TABLE.degree,
+    difficulty: 65,
+    requirements: [],
+    rewards: [{ type: "skill", target: "player.skills.management", value: 30 }],
+    awardsCredential: "degree",
+    failureRules: {
+      minimumAttendanceRatio: 80,
+      minimumStudyUnitsPerWeek: 3,
+      maximumMissedSessions: 5,
+      tuitionGraceWeeks: 3,
+      maximumStress: 85,
+      progressRetainedOnFailure: 55,
+    },
+    tags: ["university-degrees"],
+  },
+  // §7.1 "Questionable motivational seminars" — degree tier, priced and scheduled as the
+  // corpus's own joke: the most expensive, longest-running course, and the one that grants
+  // nothing a credential column can name.
+  {
+    id: "course-questionable-motivational-seminar",
+    name: {
+      key: "stable-life.course.questionable-motivational-seminar.name",
+      text: "Peak Potential: A Twenty-Four-Week Journey",
+    },
+    description: {
+      key: "stable-life.course.questionable-motivational-seminar.description",
+      text: "Nobody has ever explained what week nine covers. Week nine attendees have stopped asking.",
+    },
+    providerId: "provider-peak-potential-seminars",
+    ...EDUCATION_COST_TABLE.degree,
+    difficulty: 10,
+    requirements: [],
+    rewards: [{ type: "attribute", target: "player.attributes.charisma", value: 5 }],
+    failureRules: {
+      minimumAttendanceRatio: 50,
+      minimumStudyUnitsPerWeek: 1,
+      maximumMissedSessions: 8,
+      tuitionGraceWeeks: 0,
+      progressRetainedOnFailure: 20,
+    },
+    tags: ["questionable-motivational-seminars"],
   },
 ];
 
@@ -1071,7 +1264,7 @@ export const stableLifeSource: SimulationCampaignSource = {
   },
 
   jobs,
-  courses: [],
+  courses,
   housing,
   items: [],
   events,
@@ -1119,7 +1312,7 @@ export const stableLifeCatalog = {
     "Fifty-two weeks to turn two hundred dollars and a rented room into something that survives a bad month.",
   duration: "52 weeks",
   contentNotice:
-    "Seed content. The map, the scenario, the career ladder and 15 of 30 random events are authored; courses and possessions are not yet written.",
+    "Seed content. The map, the scenario, the career ladder, 6 courses and 15 of 30 random events are authored; possessions are not yet written.",
   featured: false,
   hidden: true,
 } as const;


### PR DESCRIPTION
## Summary

Authors §16.1's 6 courses against §7.1's education types and §16.4's education-cost table — the first content-authoring slice against the Education System (§7).

- **Short tier** ($340 / 8 weeks / 3 units): High-School Equivalency (awards `school`), Night Class: Basic Supervision (management +10)
- **Vocational tier** ($900 / 16 weeks / 4 units): Vocational Certificate: Culinary Trade (awards `certificate`, cooking +20 — the same field job-line-cook's requirement gates on), Professional Certification: Entry IT (awards `certificate`, programming +20 — the same field job-systems-administrator's requirement gates on)
- **Degree tier** ($1,600 / 24 weeks / 5 units): University Degree Module: Management (awards `degree`, management +30), Peak Potential: A Twenty-Four-Week Journey — a "questionable motivational seminar" per §7.1's own list, priced and scheduled as the corpus's own joke: the most expensive, longest-running course, and the one that grants no credential

`CourseDefinition` has no dedicated type field, so each course's §7.1 type is carried as a tag — the same mechanism S16.2 used for event types. `providerId` has no matching collection in `SimulationCampaignSource`; it is a free descriptive string, not a foreign key.

## Acceptance criteria (S17)

- [x] S17.1 — 6 courses, each a distinct §7.1 education type
- [x] S17.2 — tuition/duration/weeklyTimeCost match §16.4's education-cost table exactly, all three rows used
- [x] S17.3 — every course carries §7.4's failure rules (attendance floor, study floor, retained progress), asserted within range
- [x] S17.4 — every credential a job requirement names is produced by a course, iterated rather than restated (vacuously true — no S15 job requirement is of type `credential`)
- [x] S17.5 — every course cites its §03 section in a comment
- [x] S17.6 — `npm run check` passes; `content/stable-life.json` and `content/manifest.json` regenerated in this commit

## Descriptive correction

None — no drift found between `design/` and the tree while implementing this slice.

## Out of scope (per the slice)

The scenario's own "certificate or better" completion requirement (needs a condition over a collection the pinned engine cannot evaluate — S23), and events that fire during study (S21).

## Verified

Gates were run in this session:

- `npm run typecheck` — passes
- `npm test` (vitest) — 34/34 passing, including the 5 new S17 tests in `stable-life.test.ts` (S17.1 and S17.2 verified to fail before the content existed, for the right reason; S17.3/S17.4 iterate the (initially empty) collection so were vacuously green before authoring, non-vacuous now)
- `npm run export:content` — regenerated `content/stable-life.json` and `content/manifest.json`, committed in the same commit
- `npm run check:clean` — `content/` matches sources
- `git diff --check` — clean
- `git status --short` — clean after the full `npm run check` pipeline

Not run: the design-state checker (`tools/Test-DesignState.ps1`) and CI itself — those run on the PR; report their outcome once available rather than assuming it here.
