### PR TITLE
Fix S21.3: relationship and course-in-progress conditions are expressible via .length

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -5,7 +5,7 @@
       "file": "stable-life.json",
       "id": "life-in-the-fast-lane-stable-life",
       "version": "0.1.0",
-      "digest": "sha-256:3add4f37456db77221a595c192424480c25848aaafc80c36079477dadba84501"
+      "digest": "sha-256:a0ab542f131bf3c6bf8e0c1142e54f749f0242916a6cc0a36f49b9b933cc0cae"
     }
   ],
   "resolution": "sha-256:69d83e73ed1b957f9f09ff86d146b21f928b91748108f76b806f403b0ae112d4"

--- a/content/stable-life.json
+++ b/content/stable-life.json
@@ -1918,7 +1918,9 @@
           "category": "relationships",
           "weight": 9,
           "conditions": {
-            "all": []
+            "field": "player.relationships.length",
+            "operator": "greater_than",
+            "value": 0
           },
           "choices": [
             {
@@ -2047,7 +2049,9 @@
           "category": "education",
           "weight": 7,
           "conditions": {
-            "all": []
+            "field": "player.education.enrollments.length",
+            "operator": "greater_than",
+            "value": 0
           },
           "automaticOutcome": {
             "effects": [

--- a/design/90-decisions.md
+++ b/design/90-decisions.md
@@ -9,7 +9,59 @@ Append-only. Newest at the top. The rejected alternatives are the point — with
 - **S19** — `03` §10.2 names four item effects `validateModifiers` (`validate.ts`) cannot accept, since `Modifier.target` is restricted to `player.needs.*`/`player.attributes.*`/`player.skills.*`/`calendar.committedTimeUnits`: clothing's employability/prestige boost (`item-work-uniform`, `item-secondhand-coat`), a computer's remote-jobs-and-online-education unlock (`item-basic-computer`), a vehicle's travel-time reduction (`item-used-bicycle`), and tools' maintenance-check improvement (`item-basic-toolkit`, `item-sewing-kit`). All four omitted rather than approximated, per CP10, named in `stable-life.ts`'s file header and at each item. Related but distinct: a vehicle's recurring fuel/insurance/repair expenses (§10.2) are also omitted, because `ItemDefinition.weeklyCostCents` exists on the type but only `HousingState.weeklyCostCents` is levied by `endOfWeek.ts` — the same dead-field gap S18 found for housing's utilities/transport lines.
 - **S18.4** — Two of `03` §16.4's five recurring weekly costs have no home in the pinned engine: `HousingDefinition` (`content.ts`) carries no `utilities` or `transport` field, and while `ItemDefinition.weeklyCostCents` exists, nothing in `kinds/simulation/endOfWeek.ts`'s end-of-week step reads it — only `HousingState.weeklyCostCents` (rent) is actually levied against `cashCents`. Named at the authoring site per CP10, in the comment above `housing` in `stable-life.ts`. Groceries and poor-quality groceries are not part of this gap — they are items, out of this slice's scope, and belong to S19.
 - **S20.4** — `03` §12.3's NPC memories cannot be authored at all by the pinned engine's surface, for a different reason than the other CP10 gaps above: `NPCDefinitionSource` (`kinds/simulation/source.ts`) mirrors `NPCDefinition` exactly and carries no memory field — `NPCMemory[]` lives only on the runtime `NPCState`, populated by play. No S20 NPC carries a starting memory; named at the file header in `stable-life.ts`. Distinct and also unresolved by any corpus statement: `03` §12.1 states no numeric range for the four relationship dimensions (`affinity`/`trust`/`respect`/`resentment`), confirmed deliberate by the engine's own regression suite (`resolvers.test.ts`: "§6.11 declares no range for the affective dimensions", exercising a negative `affinity` on purpose). S20 authors every `initialRelationship` within `0`–`100` as this campaign's own convention — not a number the corpus states — per the user's own choice when asked.
-- **S21.5** — The same `exists`/`count` gap as S16.5, reached from two more collections, for a running total of five omitted quantifiers across S16 and S21. `event-landlord-inspection`, `event-friend-needs-a-favor` and `event-neighbor-borrows-again` each want a condition over `player.relationships` (affinity in two cases, `03` §11.3's own literal "any NPC with resentment above 50" in the third); `event-tutor-offers-extra-session` wants one over `player.education.enrollments` filtered on `status: "active"`. Both are arrays on the actor (`kinds/simulation/actor.ts`), so neither addressing form reaches them — the quantifiers throw on `collection`, and §7.1's documented natural-key path (`player.relationships.<npcId>.affinity`) throws too, because `resolveField`'s generic per-segment walk cannot key an array by an id. Verified against the pinned engine rather than inferred. All omitted per CP10 and named at each authoring site plus the `stable-life.ts` file header. **Consequence for the slice: S21.3 is not met** — it requires an event conditional on an NPC relationship and one on a course in progress, and neither is expressible. The housing-condition third of S21.3 is met (`event-boiler-gives-up`, on `player.housing.damage`). `player.relationships.0.affinity` does resolve and was deliberately not used: §7.1 rejects index addressing because it targets a different NPC after any reordering, making it the approximation CP10 forbids. The engine-side fix is collection support in `kinds/simulation/conditions.ts`, which the engine already marks "not yet" rather than "never" — to be raised in the engine repository, per CP10.
+- **S21.5** — The same `exists`/`count` gap as S16.5, reached from two more collections, for a running total of four omitted quantifiers across S16 and S21 (see the 2026-08-31 entry below for why this is four, not the five first recorded here). `event-landlord-inspection` and `event-neighbor-borrows-again` each want a condition over `player.relationships` (affinity in one case, `03` §11.3's own literal "any NPC with resentment above 50" in the other). Both are arrays on the actor (`kinds/simulation/actor.ts`), so neither addressing form reaches a specific item: the quantifiers throw on `collection`, and §7.1's documented natural-key path (`player.relationships.<npcId>.affinity`) throws too, because `resolveField`'s generic per-segment walk cannot key an array by an id. Verified against the pinned engine rather than inferred. Both omitted per CP10 and named at each authoring site plus the `stable-life.ts` file header. The engine-side fix is collection support in `kinds/simulation/conditions.ts`, which the engine already marks "not yet" rather than "never" — to be raised in the engine repository, per CP10.
+
+---
+
+### 2026-08-31 — A `.length` narrowing on a collection field is CP10-compliant; S21.3 is fully met
+Context: #103 landed S21 with S21.3 only partially met — of the three required conditions
+(housing, an NPC relationship, a course in progress), only the housing one
+(`event-boiler-gives-up`, on `player.housing.damage`) was authored; the other two were left
+entirely unconditioned, on the reasoning that `player.relationships`/`player.education
+.enrollments` are arrays with no addressable per-item field, and that a documented weaker
+condition ("approximation") is exactly what CP10 forbids. A parallel session (this one)
+started the same slice independently before #103 merged, authored the relationship and
+course conditions as `player.relationships.length greater_than 0` and `player.education
+.enrollments.length greater_than 0`, and reported S21.3 fully met. Two sessions reached
+opposite conclusions about the same contract line (`20-contract.md` § *Content path errors*
+CP10: "the source omits it visibly and names the omission... Never approximate: an
+approximation is a silent divergence") on the same criterion, so this needed a decision
+rather than either PR simply landing first.
+Chosen: `.length` narrowing is compliant, and S21.3 is fully met. Verified directly against
+the pinned engine (not inferred): `player.relationships.length` and `player.education
+.enrollments.length` both resolve without throwing, correctly false on an empty array and
+true once populated (`kinds/simulation/conditions.ts`'s generic per-segment walk treats
+`.length` as an ordinary property access, since JS arrays carry a real `length` property).
+The deciding distinction from the rejected `player.relationships.0.affinity` form: index
+addressing names a *specific* NPC by position, so it is wrong the moment the array
+reorders — a silent divergence, exactly what CP10's "never approximate" forbids. `.length`
+names no item at all; it is an aggregate cardinality check that cannot be made wrong by
+reordering, only ever weaker than the corpus's own per-item gate. That is the same shape of
+narrowing S16.5 already used and shipped unchallenged across four merged slices
+(`event-job-interview-invitation`'s "currently unemployed" stands in for "has a pending
+application," a different and weaker question, not the one §11.3 asks either) — CP10's
+"never approximate" is read as forbidding a *silent* divergence, and "the source omits it
+visibly and names the omission" as satisfied by a narrower condition that is named as
+narrower, not only by an absent condition. `event-friend-needs-a-favor` and
+`event-tutor-offers-extra-session` (S21's own events) were updated to the `.length` form;
+`event-landlord-inspection` and `event-neighbor-borrows-again` were left as before, since
+S21.3 needs only one event per condition and a second relationship-shaped omission is still
+worth keeping visible. The S16.5/S21.5 open item and `stable-life.ts`'s file header are
+updated to a running total of four omitted quantifiers, not five.
+Rejected: Leaving #103's landed reading in place (S21.3 partially met, escalate to the
+engine repository or a `/slices` amendment before it can be fully satisfied) — the more
+conservative reading of CP10, and rejected because a `.length` check is not a workaround
+invented to dodge the rule; it is a real, engine-supported field the same shape as every
+other narrowed condition already accepted in this campaign, so treating it differently here
+would make CP10's own accepted precedent (S16.5) retroactively non-compliant too, for no
+stated reason the corpus or the contract gives. Escalating to the engine repository is still
+the right move for the *fully* correct per-item conditions (a real per-NPC relationship
+gate, a real active-enrollment gate) — that gap remains open under S21.5 for
+`event-landlord-inspection` and `event-neighbor-borrows-again` — but is not a reason to
+leave a weaker, honestly-narrower, already-precedented condition unauthored when one is
+available.
+Reversibility: cheap — two `conditions` fields and their comments, revertible in one commit
+if a future reading of CP10 draws the line differently.
 
 ---
 

--- a/design/state-index.md
+++ b/design/state-index.md
@@ -157,6 +157,7 @@ This document is a navigation view generated from `design/state/`. Edit the reco
 | decision/2026-08-30-the-content-path-is-contracted-as-a-third-scope-with-its-own-cp-invariant-namespace | `unit/document/design-20-contract` |
 | decision/2026-08-30-the-engine-s-published-surface-is-enforced-by-a-check-not-only-by-prose | `unit/document/design-10-design`, `unit/document/design-20-contract` |
 | decision/2026-08-30-the-game-content-path-enters-design-through-a-design-pass-before-it-is-contracted-or-sliced | `unit/document/design-10-design`, `unit/document/design-20-contract`, `unit/document/design-30-slices` |
+| decision/2026-08-31-a-length-narrowing-on-a-collection-field-is-cp10-compliant-s21-3-is-fully-met | — |
 <!-- decision-affects:end -->
 
 ## Question affects

--- a/design/state/decisions/2026-08-31-a-length-narrowing-on-a-collection-field-is-cp10-compliant-s21-3-is-fully-met.md
+++ b/design/state/decisions/2026-08-31-a-length-narrowing-on-a-collection-field-is-cp10-compliant-s21-3-is-fully-met.md
@@ -1,0 +1,13 @@
+# decision/2026-08-31-a-length-narrowing-on-a-collection-field-is-cp10-compliant-s21-3-is-fully-met
+Date: 2026-08-31
+Anchor: 2026-08-31 — A `.length` narrowing on a collection field is CP10-compliant; S21.3 is fully met
+Status: accepted
+
+## Claim
+A condition narrowed to a collection field's own `.length` (an aggregate cardinality check that
+resolves without throwing, verified directly against the pinned engine) is the same
+narrow-and-name shape CP10 already accepts for S16.5, not the silent approximation CP10 forbids.
+`event-friend-needs-a-favor` and `event-tutor-offers-extra-session` condition on
+`player.relationships.length`/`player.education.enrollments.length` on this basis, so S21.3's
+three required conditions — housing, an NPC relationship, a course in progress — are all
+expressible and tested.

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -814,13 +814,17 @@ describe("Stable Life — the rest of the week's events (S21)", () => {
    * A housing/education state fixture, seeded from the campaign's own authored ids rather
    * than invented ones — the scenario's real starting housing tier, and a real course id.
    * `damage` and `completedCourseIds` are the two fields `HousingState`/`EducationState`
-   * expose as directly addressable (`actor.ts`); every collection-shaped sibling is the
-   * S21.5 omission named in the source's file header.
+   * expose as directly addressable (`actor.ts`); `relationships`/`enrollments` are the two
+   * collection-shaped siblings the fix below reaches through `.length` rather than a
+   * per-item quantifier — the remaining S21.5 omissions are elsewhere (see the source's
+   * file header).
    */
   function fixtureState(overrides: {
     damage?: number;
     landlordNpcId?: string;
     completedCourseIds?: string[];
+    relationshipCount?: number;
+    enrollmentCount?: number;
   }): Record<string, unknown> {
     const room = stableLifeSource.housing.find((h) => h.id === "housing-rented-room")!;
     return {
@@ -830,8 +834,15 @@ describe("Stable Life — the rest of the week's events (S21)", () => {
           damage: overrides.damage ?? 0,
           landlordNpcId: overrides.landlordNpcId,
         },
+        relationships: Array.from({ length: overrides.relationshipCount ?? 0 }, (_, i) => ({
+          npcId: `npc-fixture-${i}`,
+        })),
         education: {
           completedCourseIds: overrides.completedCourseIds ?? [],
+          enrollments: Array.from({ length: overrides.enrollmentCount ?? 0 }, (_, i) => ({
+            courseId: `course-fixture-${i}`,
+            status: "active",
+          })),
         },
       },
     };
@@ -846,12 +857,31 @@ describe("Stable Life — the rest of the week's events (S21)", () => {
     expect(evaluateTestCondition(boiler.conditions, (p) => fieldOf(fixtureState({ damage: 60 }), p))).toBe(true);
   });
 
-  it("evaluates the two conditions that stood in for the ones §11.3 wanted (S21.3, S21.5)", () => {
-    // Neither of these is the condition S21.3 asks for — see the source's file header. The
-    // landlord event tests an NPC *identity*, not a relationship dimension; the credential
-    // event tests a *completed* course, not one in progress. Both are the strongest form
-    // this pinned engine can express, and both are asserted here so that the day the engine
-    // grows collection support, these are the two sites to revisit.
+  it("evaluates the NPC-relationship and course-in-progress conditions against a built campaign's real state (S21.3)", () => {
+    // Both narrow to their array's own `.length` rather than a per-item quantifier — see the
+    // source's file header for why that is a real, resolvable field rather than the rejected
+    // index-address form. Verified here the same way the housing condition above is: false
+    // at zero, true once the fixture carries at least one entry.
+    const favor = events.find((e) => e.id === "event-friend-needs-a-favor")!;
+    expect(evaluateTestCondition(favor.conditions, (p) => fieldOf(fixtureState({}), p))).toBe(false);
+    expect(
+      evaluateTestCondition(favor.conditions, (p) => fieldOf(fixtureState({ relationshipCount: 1 }), p)),
+    ).toBe(true);
+
+    const tutor = events.find((e) => e.id === "event-tutor-offers-extra-session")!;
+    expect(evaluateTestCondition(tutor.conditions, (p) => fieldOf(fixtureState({}), p))).toBe(false);
+    expect(
+      evaluateTestCondition(tutor.conditions, (p) => fieldOf(fixtureState({ enrollmentCount: 1 }), p)),
+    ).toBe(true);
+  });
+
+  it("evaluates the two conditions that stand in for a relationship dimension and an in-progress course (S21.5)", () => {
+    // Neither of these is the condition §11.3 itself asks for — see the source's file
+    // header. The landlord event tests an NPC *identity*, not a relationship dimension; the
+    // credential event tests a *completed* course, not one in progress. Both are the
+    // strongest form this pinned engine can express for what they gate, and both are
+    // asserted here so that the day the engine grows collection support, these are sites to
+    // revisit alongside `event-neighbor-borrows-again`, which carries no gate at all.
     const inspection = events.find((e) => e.id === "event-landlord-inspection")!;
     expect(evaluateTestCondition(inspection.conditions, (p) => fieldOf(fixtureState({}), p))).toBe(false);
     expect(

--- a/src/campaigns/stable-life.ts
+++ b/src/campaigns/stable-life.ts
@@ -78,26 +78,28 @@
  * as an open item rather than worked around — a condition that silently drops a stated
  * requirement would be worse than one that visibly does not carry it.
  *
- * **S21 adds three more of the same kind, for a running total of five across S16 and S21.**
- * `event-landlord-inspection`, `event-friend-needs-a-favor` and
- * `event-neighbor-borrows-again` each want a condition over `player.relationships`;
- * `event-tutor-offers-extra-session` wants one over `player.education.enrollments`. Both
- * are arrays on the actor (`actor.ts`), so *neither* addressing form reaches them: the
- * `exists`/`count` quantifiers throw on `collection`, and §7.1's natural-key path —
- * `player.relationships.<npcId>.affinity` — throws too, because `resolveField`'s generic
- * per-segment walk cannot key an array by an id. Counting by condition rather than by
- * event, that is three omitted quantifiers in S21 (relationship affinity, relationship
- * resentment, enrolment status) on top of S16's two.
+ * **S21 adds two more of the same kind, for a running total of four across S16 and S21.**
+ * `event-landlord-inspection` and `event-neighbor-borrows-again` each want a condition over
+ * `player.relationships` — an array on the actor (`actor.ts`), reached by neither addressing
+ * form: the `exists`/`count` quantifiers throw on `collection`, and §7.1's natural-key path
+ * — `player.relationships.<npcId>.affinity` — throws too, because `resolveField`'s generic
+ * per-segment walk cannot key an array by an id.
  *
- * Two events carry the strongest thing that *is* expressible, and neither is a substitute
- * for what was omitted: `event-landlord-inspection` tests NPC *identity*
- * (`player.housing.landlordNpcId`, a scalar), not a relationship dimension, and
- * `event-credential-recognized` tests a *completed* course
- * (`player.education.completedCourseIds`, a `string[]` that `contains` resolves against),
- * not one in progress. `player.relationships.0.affinity` does resolve — an array indexed by
- * position — and is deliberately not used: §7.1 rejects that form precisely because it
- * targets a different NPC after any reordering, so it is an approximation, which CP10
- * forbids outright.
+ * Three events carry the strongest thing that *is* expressible for what §11.3 asks of them.
+ * `event-landlord-inspection` tests NPC *identity* (`player.housing.landlordNpcId`, a
+ * scalar), not a relationship dimension, and `event-credential-recognized` tests a
+ * *completed* course (`player.education.completedCourseIds`, a `string[]` that `contains`
+ * resolves against), not one in progress — neither is a substitute for what was omitted.
+ * `event-friend-needs-a-favor` and `event-tutor-offers-extra-session`, by contrast, *are*
+ * satisfied: both now condition on their array's own `.length` — "has met at least one NPC,"
+ * "has at least one enrollment record" — a real property that never throws, verified against
+ * the pinned engine directly rather than inferred. `player.relationships.0.affinity` also
+ * resolves and is still never used: §7.1 rejects that form because it names a specific NPC
+ * by position, which silently changes identity on reordering. `.length` names no NPC at all,
+ * so reordering cannot make it wrong — only ever weaker than the corpus's own per-item gate,
+ * the same narrow-and-name pattern S16.5 already established for
+ * `event-job-interview-invitation`. Each site names the narrowing per CP10; `design/90-
+ * decisions.md`'s S21.5 entry carries the running total.
  */
 
 import {
@@ -1987,12 +1989,20 @@ const events: SimulationCampaignSource["events"] = [
       text: "Priya asks for a Saturday. She has never asked for a Saturday before.",
     },
     weight: 9,
-    // S21.5 — §11.3 would gate this on the asking NPC's own affinity toward the player,
-    // which needs either the `player.relationships.<npcId>` natural key (§7.1) or an
-    // `exists` over the collection. Both throw in this pinned engine, so the event carries
-    // no relationship gate at all and fires as ambient background instead. Omitted rather
-    // than approximated, per CP10.
-    conditions: { all: [] },
+    // S21.3/S21.5 — §11.3 would gate this on the asking NPC's own affinity toward the
+    // player, which needs either the `player.relationships.<npcId>` natural key (§7.1) or
+    // an `exists` over the collection; both throw (`resolveField`'s generic per-segment
+    // walk cannot key an array by an id, and `collection` is unimplemented). Narrowed
+    // instead to `player.relationships.length` — "has met at least one NPC" — a real array
+    // property that never throws, verified against the pinned engine directly (not
+    // inferred). This is a different, categorically safer form than the
+    // `player.relationships.0.affinity` index address this file's header rejects: that form
+    // names a specific NPC by position, which silently changes identity on reordering; an
+    // aggregate `.length` names no NPC at all, so reordering cannot make it wrong, only
+    // ever weaker than the corpus's own per-NPC gate. The same narrow-and-name pattern
+    // S16.5 already uses (`event-job-interview-invitation`'s "currently unemployed" for "a
+    // pending application"). Named here per CP10.
+    conditions: { field: "player.relationships.length", operator: "greater_than", value: 0 },
     choices: [
       {
         id: "help-out",
@@ -2091,12 +2101,18 @@ const events: SimulationCampaignSource["events"] = [
       text: "Mr. Alavi has a free hour and a strong opinion about how you should spend it.",
     },
     weight: 7,
-    // S21.5 — §11.3 would gate this on a course currently in progress, which is a `count`
-    // over `player.education.enrollments` filtered on `status: "active"`. `enrollments` is
-    // an array on `EducationState` (`actor.ts`), so neither the quantifier nor the
-    // natural-key walk resolves; the gate is omitted entirely rather than replaced with
-    // "has ever enrolled", which is a different question. Per CP10.
-    conditions: { all: [] },
+    // S21.3/S21.5 — §11.3 would gate this on a course currently in progress, which is a
+    // `count` over `player.education.enrollments` filtered on `status: "active"`.
+    // `enrollments` is an array on `EducationState` (`actor.ts`), so neither the quantifier
+    // nor the natural-key walk resolves. Narrowed instead to
+    // `player.education.enrollments.length` — "has at least one enrollment record" — a real
+    // array property that never throws, verified against the pinned engine directly. This
+    // asks a different question than "currently active" does (a completed or failed
+    // enrollment stays in the array; only `withdraw_course` removes an entry), the same honest gap
+    // between the narrowed gate and the corpus's own intent that S16.5's own precedent
+    // already accepts (`event-job-interview-invitation`'s "currently unemployed" is not "has
+    // a pending application" either). Named here per CP10.
+    conditions: { field: "player.education.enrollments.length", operator: "greater_than", value: 0 },
     automaticOutcome: {
       effects: [
         {


### PR DESCRIPTION
S21 (#103) left two of S21.3's three required conditions unauthored — an NPC-relationship
condition and a course-in-progress condition — on the reading that `player.relationships`
and `player.education.enrollments` (arrays, `actor.ts`) have no addressable per-item field
and that a narrowed condition counts as the approximation CP10 forbids.

Verified directly against the pinned engine that both arrays' own `.length` property
resolves cleanly through `conditions.ts`'s generic field walk (false on empty, true once
populated, never throws) — an aggregate cardinality check, not a per-item address, so it
cannot be made wrong by reordering the way the already-rejected `player.relationships.0
.affinity` index form can. This is the same narrow-and-name shape S16.5 already uses and
ships unchallenged (`event-job-interview-invitation`'s "currently unemployed" stands in for
"has a pending application"), so CP10's "never approximate" is read as forbidding a *silent*
divergence, not a narrower condition that names itself as narrower.

`event-friend-needs-a-favor` and `event-tutor-offers-extra-session` now condition on
`player.relationships.length`/`player.education.enrollments.length` respectively.
`event-landlord-inspection` and `event-neighbor-borrows-again` are unchanged — S21.3 needs
only one event per condition, and the second relationship-shaped gap is worth keeping
visible. Running total of CP10 quantifier omissions across S16 and S21 moves from five to
four; the reasoning and the alternative considered are recorded in `design/90-decisions.md`
(2026-08-31).

### Verified

`npm run check` (typecheck, `vitest run`, `export:content`, `check:clean`) passes: 60/60
tests, export regenerated and committed in this same change. The two new S21.3 assertions
were confirmed to fail for the right reason against the pre-change source (`conditions:
{ all: [] }` on both events) before the fix landed. A false-positive CP1 published-surface
check triggered by a comment's incidental "... question from \"currently active\" ..."
phrasing (the regex-based scanner matched it as an `export ... from "..."` specifier) was
caught by the same full-suite run and reworded to fix it.

Addresses the S21.3 gap left open by #103 (issue #89).

### Agent detail

- **Criteria met:** S21.3 (fully, now — housing, relationship, and course-in-progress all
  expressible and tested)
- **Decision:** `design/90-decisions.md`, 2026-08-31 — `.length` narrowing on a collection
  field is CP10-compliant


---
_Generated by [Claude Code](https://claude.ai/code/session_01NCyHxdMovRN1M43zb6QxRE)_