### PR TITLE
S23 — The scenario is finishable, and there is more than one thing to aim at

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -5,7 +5,7 @@
       "file": "stable-life.json",
       "id": "life-in-the-fast-lane-stable-life",
       "version": "0.1.0",
-      "digest": "sha-256:3add4f37456db77221a595c192424480c25848aaafc80c36079477dadba84501"
+      "digest": "sha-256:6484fde9a1e00a08395bd91277145c72956f8252378ac41dbbeea314cf5494af"
     }
   ],
   "resolution": "sha-256:69d83e73ed1b957f9f09ff86d146b21f928b91748108f76b806f403b0ae112d4"

--- a/content/stable-life.json
+++ b/content/stable-life.json
@@ -2582,18 +2582,75 @@
           },
           "labelKey": "stable-life.goal.stable-life.label",
           "descriptionKey": "stable-life.goal.stable-life.description"
+        },
+        {
+          "id": "goal-financial-cushion",
+          "category": "wealth",
+          "conditions": {
+            "field": "player.finances.cashCents",
+            "operator": "greater_or_equal",
+            "value": 50000
+          },
+          "requiredDurationWeeks": 8,
+          "labelKey": "stable-life.goal.financial-cushion.label",
+          "descriptionKey": "stable-life.goal.financial-cushion.description"
+        },
+        {
+          "id": "goal-career-advancement",
+          "category": "career",
+          "conditions": {
+            "any": [
+              {
+                "field": "player.career.highestTierAchieved",
+                "operator": "equals",
+                "value": "professional"
+              },
+              {
+                "field": "player.career.highestTierAchieved",
+                "operator": "equals",
+                "value": "senior"
+              }
+            ]
+          },
+          "labelKey": "stable-life.goal.career-advancement.label",
+          "descriptionKey": "stable-life.goal.career-advancement.description"
+        },
+        {
+          "id": "goal-certified-professional",
+          "category": "education",
+          "conditions": {
+            "field": "player.education.completedCourseIds",
+            "operator": "contains",
+            "value": "course-professional-certification-it"
+          },
+          "labelKey": "stable-life.goal.certified-professional.label",
+          "descriptionKey": "stable-life.goal.certified-professional.description"
         }
       ],
       "scenarios": [
         {
           "id": "scenario-stable-life",
-          "startingBackgroundIds": [],
+          "startingBackgroundIds": [
+            "background-kitchen-hand"
+          ],
           "startingCashCents": 20000,
           "startingHousingId": "housing-rented-room",
           "startingLocationId": "home",
-          "startingInventory": [],
+          "startingInventory": [
+            {
+              "definitionId": "item-groceries-poor",
+              "quantity": 1
+            },
+            {
+              "definitionId": "item-secondhand-coat",
+              "quantity": 1
+            }
+          ],
           "goalIds": [
-            "goal-stable-life"
+            "goal-stable-life",
+            "goal-financial-cushion",
+            "goal-career-advancement",
+            "goal-certified-professional"
           ],
           "weekLimit": 52,
           "mode": "classic",
@@ -3031,6 +3088,12 @@
     "stable-life.event.tutor-offers-extra-session.title": "An Extra Session",
     "stable-life.event.winter-flu.description": "Everyone at work had it. Now it is your turn, and the week has other plans.",
     "stable-life.event.winter-flu.title": "Winter Flu",
+    "stable-life.goal.career-advancement.description": "Professional work, or better.",
+    "stable-life.goal.career-advancement.label": "Career Advancement",
+    "stable-life.goal.certified-professional.description": "Finish the entry IT certification.",
+    "stable-life.goal.certified-professional.label": "Certified Professional",
+    "stable-life.goal.financial-cushion.description": "Five hundred dollars in hand, and keep it there for eight straight weeks.",
+    "stable-life.goal.financial-cushion.label": "A Financial Cushion",
     "stable-life.goal.stable-life.description": "Two thousand dollars, skilled work, sixty happiness, sixty health, and nothing overdue. Twelve months.",
     "stable-life.goal.stable-life.label": "A Stable Life",
     "stable-life.housing.cheap-studio.description": "One room, but it is the whole apartment, and nobody else's name is on the lease.",

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -7,6 +7,8 @@
  * would leave the scaffold looking finished and producing nothing.
  */
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 import {
   buildValidatedContentRegistry,
@@ -901,6 +903,168 @@ describe("Stable Life — the rest of the week's events (S21)", () => {
   });
 
   it("builds and validates with the full 30-event set wired in (S21.6)", () => {
+    const result = buildStableLifeCampaign();
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    const registry = buildValidatedContentRegistry([built()], kinds);
+    expect(registry.errors).toEqual([]);
+    expect(registry.ok).toBe(true);
+  });
+});
+
+describe("Stable Life — goals and victory (S23)", () => {
+  const goals = stableLifeSource.goals;
+  const scenario = stableLifeSource.scenarios[0]!;
+
+  it("covers 4 of §13's goal categories, the existing scenario goal among them (S23.1)", () => {
+    expect(goals.some((g) => g.id === "goal-stable-life" && g.category === "scenario")).toBe(true);
+    const categories = new Set(goals.map((g) => g.category));
+    expect(categories.size).toBe(4);
+  });
+
+  it("has at least one persistent goal, its consecutive-week count present and greater than one (S23.2)", () => {
+    const persistent = goals.filter((g) => g.requiredDurationWeeks !== undefined);
+    expect(persistent.length).toBeGreaterThan(0);
+    for (const goal of persistent) {
+      expect(goal.requiredDurationWeeks!).toBeGreaterThan(1);
+    }
+  });
+
+  it("carries a starting background from S22 and a starting inventory drawn from S19's items, every id resolving (S23.3)", () => {
+    expect(scenario.startingBackgroundIds.length).toBeGreaterThan(0);
+    const backgroundIds = new Set(stableLifeSource.backgrounds.map((b) => b.id));
+    for (const id of scenario.startingBackgroundIds) {
+      expect(backgroundIds.has(id), `unknown background "${id}"`).toBe(true);
+    }
+
+    expect(scenario.startingInventory.length).toBeGreaterThan(0);
+    const itemIds = new Set(stableLifeSource.items.map((i) => i.id));
+    for (const entry of scenario.startingInventory) {
+      expect(itemIds.has(entry.definitionId), `unknown item "${entry.definitionId}"`).toBe(true);
+    }
+  });
+
+  it("still omits §16.3's credential completion requirement, the open decision-log entry still open (S23.4)", () => {
+    // `player.education.credentials` is a collection (`Credential[]`, `actor.ts`); the
+    // pinned engine's `exists`/`count` quantifiers throw on `collection` (file header,
+    // and S16.5/S21.5's identical finding). Not expressible as a scalar comparison either
+    // — there is no `highestCredentialLevel` field. Still omitted; the decision-log entry
+    // this slice was asked to confirm is `## Open`'s S16.5, which names this same gap and
+    // has not been converted to an issue or closed.
+    const stableLifeGoal = goals.find((g) => g.id === "goal-stable-life")!;
+    const conditionText = JSON.stringify(stableLifeGoal.conditions);
+    expect(conditionText).not.toContain("credential");
+
+    const decisionsLog = readFileSync(
+      new URL("../../design/90-decisions.md", import.meta.url),
+      "utf8",
+    );
+    const openSection = decisionsLog.slice(
+      decisionsLog.indexOf("## Open"),
+      decisionsLog.indexOf("\n## ", decisionsLog.indexOf("## Open") + 1),
+    );
+    expect(openSection).toContain("S16.5");
+    expect(openSection).toContain("credential completion requirement");
+  });
+
+  function evaluateTestCondition(condition: Condition, resolveField: (path: string) => unknown): boolean {
+    if ("all" in condition) return condition.all.every((c) => evaluateTestCondition(c, resolveField));
+    if ("any" in condition) return condition.any.some((c) => evaluateTestCondition(c, resolveField));
+    if ("not" in condition) return !evaluateTestCondition(condition.not, resolveField);
+    if ("exists" in condition || "count" in condition) {
+      throw new Error("this campaign's goal conditions never use a collection quantifier (S23.4)");
+    }
+    const actual = resolveField(condition.field);
+    switch (condition.operator) {
+      case "equals": return actual === condition.value;
+      case "not_equals": return actual !== condition.value;
+      case "greater_or_equal": return (actual as number) >= (condition.value as number);
+      case "less_or_equal": return (actual as number) <= (condition.value as number);
+      case "contains": return Array.isArray(actual) && actual.includes(condition.value);
+      default:
+        throw new Error(`test evaluator: extend for operator "${condition.operator}"`);
+    }
+  }
+
+  function fieldOf(state: Record<string, unknown>, path: string): unknown {
+    return path.split(".").reduce<unknown>((current, segment) => {
+      if (current === null || typeof current !== "object") return undefined;
+      return (current as Record<string, unknown>)[segment];
+    }, state);
+  }
+
+  /** A finances/career/needs/education fixture built from the scenario's own starting
+   *  numbers and real content ids, not invented ones. */
+  function fixtureState(overrides: {
+    cashCents?: number;
+    overdueBalanceCents?: number;
+    careerTier?: string;
+    happiness?: number;
+    health?: number;
+    completedCourseIds?: string[];
+  }): Record<string, unknown> {
+    return {
+      player: {
+        finances: {
+          cashCents: overrides.cashCents ?? scenario.startingCashCents,
+          overdueBalanceCents: overrides.overdueBalanceCents ?? 0,
+        },
+        career: { highestTierAchieved: overrides.careerTier },
+        needs: { happiness: overrides.happiness ?? 50, health: overrides.health ?? 50 },
+        education: { completedCourseIds: overrides.completedCourseIds ?? [] },
+      },
+    };
+  }
+
+  it("evaluates every goal's conditions against a built campaign, both false and true (S23.5)", () => {
+    built(); // proves the campaign actually builds before conditions are evaluated against it
+
+    for (const goal of goals) {
+      const atStart = evaluateTestCondition(goal.conditions, (p) => fieldOf(fixtureState({}), p));
+      expect(atStart, `${goal.id} should not already be met at the scenario's starting state`).toBe(false);
+    }
+
+    const stableLifeGoal = goals.find((g) => g.id === "goal-stable-life")!;
+    expect(
+      evaluateTestCondition(
+        stableLifeGoal.conditions,
+        (p) =>
+          fieldOf(
+            fixtureState({ cashCents: 2000_00, careerTier: "skilled", happiness: 60, health: 60 }),
+            p,
+          ),
+      ),
+    ).toBe(true);
+
+    const cushion = goals.find((g) => g.id === "goal-financial-cushion")!;
+    expect(
+      evaluateTestCondition(cushion.conditions, (p) => fieldOf(fixtureState({ cashCents: 500_00 }), p)),
+    ).toBe(true);
+
+    const advancement = goals.find((g) => g.id === "goal-career-advancement")!;
+    expect(
+      evaluateTestCondition(advancement.conditions, (p) => fieldOf(fixtureState({ careerTier: "senior" }), p)),
+    ).toBe(true);
+
+    const certified = goals.find((g) => g.id === "goal-certified-professional")!;
+    expect(
+      evaluateTestCondition(
+        certified.conditions,
+        (p) =>
+          fieldOf(fixtureState({ completedCourseIds: ["course-professional-certification-it"] }), p),
+      ),
+    ).toBe(true);
+  });
+
+  it("resolves every id the scenario's goalIds name (S23.5)", () => {
+    const goalIds = new Set(goals.map((g) => g.id));
+    expect(scenario.goalIds.length).toBeGreaterThan(0);
+    for (const id of scenario.goalIds) {
+      expect(goalIds.has(id), `scenario names unknown goal "${id}"`).toBe(true);
+    }
+  });
+
+  it("builds and validates with the full goal/scenario set wired in (S23.6)", () => {
     const result = buildStableLifeCampaign();
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);

--- a/src/campaigns/stable-life.ts
+++ b/src/campaigns/stable-life.ts
@@ -2352,6 +2352,26 @@ const events: SimulationCampaignSource["events"] = [
  * express yet (see the file header). `highestTierAchieved` is a string, so "skilled or
  * better" is authored as the explicit set rather than an ordering comparison — the tier
  * union has no numeric rank the evaluator could compare against.
+ *
+ * §13's goal category list is a prose enumeration, not a code-level enum — `category` is a
+ * free `string` on `GoalDefinition` (`content.ts`). §16.1 targets four goal categories; the
+ * three below are chosen from fields the pinned engine can already address without a
+ * collection quantifier (the same restriction the file header documents for events),
+ * alongside `goal-stable-life`'s own `"scenario"` — four distinct categories total (S23.1).
+ *
+ * `goal-financial-cushion` is the persistent one §13.1 asks for (S23.2): the corpus's own
+ * example is an eight-consecutive-week maintenance goal, reused here at a lower cash
+ * threshold than the scenario goal so it reads as a stepping stone rather than a restatement.
+ * `requiredDurationWeeks` is `GoalDefinition`'s field for it; the engine resets the
+ * consecutive-week counter on any week the condition fails (04 §13.1), which this file has
+ * no state to exercise directly — asserted here only as "present and greater than one",
+ * per S23.2's own wording.
+ *
+ * `goal-career-advancement` and `goal-certified-professional` are stretch goals against
+ * S15/S17 content already authored — a tier above the scenario goal's "skilled or better",
+ * and a specific course completion rather than the scenario's omitted credential-level
+ * check. Both are ordinary `player.career.*`/`player.education.completedCourseIds` field
+ * reads, the same forms the scenario goal and `event-credential-recognized` already use.
  */
 const goals: SimulationCampaignSource["goals"] = [
   {
@@ -2378,9 +2398,62 @@ const goals: SimulationCampaignSource["goals"] = [
       ],
     },
   },
+  {
+    id: "goal-financial-cushion",
+    label: { key: "stable-life.goal.financial-cushion.label", text: "A Financial Cushion" },
+    description: {
+      key: "stable-life.goal.financial-cushion.description",
+      text: "Five hundred dollars in hand, and keep it there for eight straight weeks.",
+    },
+    category: "wealth",
+    conditions: { field: "player.finances.cashCents", operator: "greater_or_equal", value: DOLLARS(500) },
+    requiredDurationWeeks: 8,
+  },
+  {
+    id: "goal-career-advancement",
+    label: { key: "stable-life.goal.career-advancement.label", text: "Career Advancement" },
+    description: {
+      key: "stable-life.goal.career-advancement.description",
+      text: "Professional work, or better.",
+    },
+    category: "career",
+    conditions: {
+      any: [
+        { field: "player.career.highestTierAchieved", operator: "equals", value: "professional" },
+        { field: "player.career.highestTierAchieved", operator: "equals", value: "senior" },
+      ],
+    },
+  },
+  {
+    id: "goal-certified-professional",
+    label: { key: "stable-life.goal.certified-professional.label", text: "Certified Professional" },
+    description: {
+      key: "stable-life.goal.certified-professional.description",
+      text: "Finish the entry IT certification.",
+    },
+    category: "education",
+    conditions: {
+      field: "player.education.completedCourseIds",
+      operator: "contains",
+      value: "course-professional-certification-it",
+    },
+  },
 ];
 
-/** §16.3 — twelve months to establish a stable life. */
+/**
+ * §16.3 — twelve months to establish a stable life. `startingBackgroundIds` names
+ * `background-kitchen-hand` (S23.3): of S22's three, it is the one whose
+ * `startingCashModifierCents` is `0` (`initial.ts` sums every listed background's modifier
+ * into `scenario.startingCashCents`), so the player's actual starting cash stays §16.3's
+ * literal $200 — the number this file states three times over (here, the scenario
+ * description below, and the catalog card). `background-office-temp`'s `"school"`
+ * credential reads closer to §16.3's loose "Basic education" phrase, but that is prose
+ * flavor text where $200 is a specific, repeated figure; preserving the figure exactly
+ * is the choice made here. `startingInventory` is §16.3's "one week of food"
+ * (`item-groceries-poor`, matching the scenario's tight-budget framing over the pricier
+ * `item-groceries-basic`) plus one of "minimal possessions" (`item-secondhand-coat`), both
+ * from S19's items.
+ */
 const scenarios: SimulationCampaignSource["scenarios"] = [
   {
     id: STABLE_LIFE_SCENARIO_ID,
@@ -2389,12 +2462,15 @@ const scenarios: SimulationCampaignSource["scenarios"] = [
       key: "stable-life.scenario.description",
       text: "Two hundred dollars, no job, basic education, a rented room, one week of food, and fifty-two weeks.",
     },
-    startingBackgroundIds: [],
+    startingBackgroundIds: ["background-kitchen-hand"],
     startingCashCents: DOLLARS(200),
     startingHousingId: "housing-rented-room",
     startingLocationId: "home",
-    startingInventory: [],
-    goalIds: ["goal-stable-life"],
+    startingInventory: [
+      { definitionId: "item-groceries-poor", quantity: 1 },
+      { definitionId: "item-secondhand-coat", quantity: 1 },
+    ],
+    goalIds: ["goal-stable-life", "goal-financial-cushion", "goal-career-advancement", "goal-certified-professional"],
     weekLimit: 52,
     mode: "classic",
     goalFailurePrecedence: "goals_win",


### PR DESCRIPTION
Authors three more goals alongside `goal-stable-life`, and gives the Stable Life scenario a
starting background and starting inventory — the two `Touches` this slice's acceptance criteria
name.

### Goals — 4 categories, one persistent (S23.1, S23.2)

`goal-financial-cushion` (`wealth`, $500 maintained for 8 consecutive weeks — `03` §13.1's own
example shape, at a lower threshold than the scenario goal so it reads as a stepping stone),
`goal-career-advancement` (`career`, professional tier or better), and
`goal-certified-professional` (`education`, the entry IT certification course completed) join
`goal-stable-life` (`scenario`) for four distinct categories, matching §16.1's target.
`goal-financial-cushion` carries `requiredDurationWeeks: 8` — the field `GoalDefinition` exposes
for §13.1's persistent-goal shape.

### Scenario starting state (S23.3)

`startingBackgroundIds: ["background-kitchen-hand"]` — chosen over `background-office-temp`
because its `startingCashModifierCents` is `0`; `office-temp`'s `+$20` would have broken the
literal $200 cash figure this file states three times over (§16.3, the scenario description,
the catalog card), and that repeated, specific number outweighs `office-temp`'s slightly closer
match to §16.3's loose "Basic education" phrase. `startingInventory` is §16.3's "one week of
food" (`item-groceries-poor`) plus one of "minimal possessions" (`item-secondhand-coat`), both
from S19.

### The credential requirement stays omitted (S23.4)

§16.3's "Education: certificate or better" is still not expressible: `player.education
.credentials` is a `Credential[]` (a collection), and the pinned engine's `exists`/`count`
quantifiers throw on `collection` — the same gap S16.5 and S21.5 already recorded, with no
scalar `highestCredentialLevel`-shaped field to fall back on. The `## Open` entry (S16.5) that
names this gap is confirmed still open in `design/90-decisions.md`; nothing here re-logs it.

### Filed upstream

While confirming S21.3's engine limitation was still current (the engine pin hasn't moved since
it was recorded), filed
[SubZeroDev.GameEngine#418](https://github.com/The-Running-Dev/SubZeroDev.GameEngine/issues/418)
asking for collection-addressed conditions over actor-owned arrays — the same underlying gap
behind both S21.3 and this slice's S23.4.

### Verified

`npm run check` (typecheck, `vitest run`, `export:content`, `check:clean`) passes: 66/66 tests,
export byte-identical to the committed JSON, `content/ matches the sources`. The new goal tests
were run against the pre-change source first and failed for the right reason (one goal, one
category, no persistent goal, empty starting background/inventory) before the implementation
landed.

The repository's PowerShell gates (`Test-DesignState.ps1`, `Test-SpecSet.ps1`, the Pester suite)
**did not run** — `pwsh` is not available in this session — and are not claimed here.

### Agent detail

- **Slice:** S23 — `design/30-slices.md` § S23 @ `1ec3337099d3ad2b763987c14cef6cdd67e2b05a`
- **Criteria met:** S23.1, S23.2, S23.3, S23.4, S23.5, S23.6
- **Judgement calls the contract didn't determine:** which background/inventory the scenario
  carries (documented above and at the authoring site); which three §13 categories to add,
  chosen from fields already expressible without a collection quantifier

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv9TJE7ZqogFHQspjA39NS)_