### PR TITLE
reconcile: CP2 binds the invoked export, and S23.4's Open guard is bounded

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ and its content**. The engine and the hosting layer are separate companion repos
 Fast Lane* (Sierra, 1990), the flagship `simulation`-kind game of the Narrative Engine. Two
 halves, both owned here:
 
-1. **The specs** (`docs/docs/games/`) — the detailed spec set, ~105 KB of engine document.
+1. **The specs** (`docs/docs/games/`) — the detailed spec set, ~115 KB of engine document.
 2. **The content** (`src/campaigns/` → `content/`) — the campaign sources themselves, authored
    against the engine's published authoring surface and exported as portable JSON.
 
@@ -53,7 +53,7 @@ number.
 | `docs/docs/games/01-vision.md` | Why the game exists, creative principles, non-goals, risks |
 | `docs/docs/games/02-narrative-voice.md` | The narrator, tone rules, long-arc gags. **The project's strongest asset** |
 | `docs/docs/games/03-game-design.md` | Mechanics, numbers, content targets, the map, the scenario |
-| `docs/docs/games/04-engine-specification.md` | Types, API, systems, testing, phases (~105 KB) |
+| `docs/docs/games/04-engine-specification.md` | Types, API, systems, testing, phases (~115 KB) |
 | `docs/docs/games/05-text-client.md` | The first client, and the instrument that proves the API |
 | `docs/docs/games/life-in-the-fast-lane.md` | **Game 1** — the `simulation` kind (Jones clone). Depth milestone; Bulgaria is its culture pack. Full spec is `docs/docs/games/01`–`05` |
 | `docs/docs/games/bulgaria-adventure.md` | **Game 2** — the `story-graph` kind (make-your-own-adventure). The MVP vehicle |

--- a/agent.md
+++ b/agent.md
@@ -1,7 +1,7 @@
 # Agent — Lessons Learned
 
 Retrospective notes for whoever works this **game** repo next. Standing *instructions* live
-in [`CLAUDE.md`](CLAUDE.md); durable *facts/preferences* live in the memory dir. This file
+in [`AGENTS.md`](AGENTS.md); durable *facts/preferences* live in the memory dir. This file
 is what we learned the hard way.
 
 Keep this file short — it loads into context, so length is a recurring cost. Add a lesson
@@ -20,10 +20,10 @@ only when it would have changed a decision.
    is marginal — reading the docs directly found 12 inconsistencies; graphify found ~2. The
    TypeScript in `src/campaigns/` takes the free AST path, but it is dwarfed by the specs, so
    the cost profile is unchanged. Use `--cluster-only` / `query`;
-   avoid full rebuilds. (The `--update` edge-loss trap: `CLAUDE.md`.)
+   avoid full rebuilds. (The `--update` edge-loss trap: `AGENTS.md`.)
 2. **Skill prompts inject their whole instruction file** on invocation. Only invoke a skill
    you will actually use.
-3. **Full-file reads and large specs.** `04-engine-specification.md` is ~104KB (~30K
+3. **Full-file reads and large specs.** `04-engine-specification.md` is ~115KB (~33K
    tokens/read). Prefer grep / offset-limit when you know what you need.
 4. **Start a fresh session at phase boundaries.** `CLAUDE.md` + memory + the docs re-prime a
    new session cheaply — that's why they're kept tight.
@@ -74,7 +74,7 @@ only when it would have changed a decision.
 ## Orientation in one paragraph
 
 This repo = **Life in the Fast Lane** (`docs/docs/games/`), a Jones-clone life-sim = the
-`simulation` kind — **game specs only**. The **engine** (source + specs) is the companion
+`simulation` kind — **its specs and its campaign content** (`src/campaigns/` → `content/`). The **engine** (source + specs) is the companion
 [SubZeroDev.GameEngine](https://github.com/The-Running-Dev/SubZeroDev.GameEngine); hosting
 is [SubZeroDev.Platform](https://github.com/The-Running-Dev/SubZeroDev.Platform). Bulgaria
 is *two different games* — a culture pack on Jones (simulation), and a story-graph

--- a/design/20-contract.md
+++ b/design/20-contract.md
@@ -556,8 +556,8 @@ where it is a different question standing in for the one the corpus asked.
 Declared in [`scripts/export-content.ts`](../scripts/export-content.ts). The `entries` list is
 the publication catalog and is this file's most important surface.
 
-**It is the only production writer in either system, and `content/` is its only write target**
-(CP2).
+**It is the only production writer in either system, and `content/` is the only directory the
+invoked export writes** (CP2).
 
 **It builds every campaign and validates the whole set before writing any file** (CP4), so an
 authoring or validation failure leaves the directory byte-identical. That ordering is the
@@ -571,10 +571,24 @@ visible to a person; minifying the output would remove the second of those and b
 **It removes every `.json` under `content/` the catalog does not name** (CP6). That is what
 makes a retired or renamed campaign disappear rather than linger.
 
-**No parameter may make it write elsewhere or write a subset.** There is no `--out-dir` and no
-`--only`, and adding either defeats CP4 and CP6 at once: a partial export is indistinguishable
-from a stale one to the clean check, which is the only thing standing between a source edit and
-a silently unpublished change.
+**No command-line parameter may make it write elsewhere or write a subset.** There is no
+`--out-dir` and no `--only`, and adding either defeats CP4 and CP6 at once: a partial export is
+indistinguishable from a stale one to the clean check, which is the only thing standing between a
+source edit and a silently unpublished change.
+
+**`exportContent` takes its catalog and its output directory as arguments, and the rule above
+binds the invoked surface rather than that signature.** `main()` supplies the module's `entries`
+and `outputDir`, and nothing else calls it in production, so what is published is what the rule
+describes. The arguments are what lets the exporter's error table be exercised at all:
+`CampaignDidNotBuild` and `ValidationRejected` need a catalog that fails, and `WriteFailed` needs
+a filesystem that rejects a real write — which `90-decisions.md` (2026-09-01, `WriteFailed`) chose
+over a stub, and which cannot be aimed at the published directory without publishing from it. The
+scope carries the obligation the production-source scope on CP2 and CP3 already carries: **a test
+that leaves `content/` differing from the committed export has failed, whatever else it
+asserted**, which is why each one ends on a `git status` assertion. **What the evidence check
+proves is correspondingly narrower than its name reads**: it resolves the exporter's writes to the
+binding spelled `outputDir`, which inside `exportContent` is the argument and not the module
+constant it checks separately.
 
 #### `scripts/check-clean.mjs`
 
@@ -1011,7 +1025,7 @@ fails when the row is broken**, and an em dash means nothing enforces it yet.
 | Id | Invariant | Owner | Enforcement | Evidence |
 |---|---|---|---|---|
 | **CP1** | No source in this repository imports the engine by anything other than `@the-running-dev/game-engine` or its `/authoring` subpath, and no relative import escapes this repository's own sources | Campaign sources, Exporter | Code | `src/published-surface.test.ts` |
-| **CP2** | `content/` has exactly one production writer, and it writes nowhere else | Exporter | Code | `src/published-surface.test.ts` |
+| **CP2** | `content/` has exactly one production writer, and the invoked export writes nowhere else | Exporter | Code | `src/published-surface.test.ts` |
 | **CP3** | No production source in this repository reads a file under `content/` | All | Code | `src/published-surface.test.ts` |
 | **CP4** | Every campaign builds and the whole set validates before any file is written; a failure before the write phase leaves `content/` byte-identical | Exporter | Code | `src/export-content.test.ts` |
 | **CP5** | Two exports from the same sources and the same pin produce byte-identical files | Exporter | Code | `.github/workflows/verify.yml`, step *Re-export content and fail if the committed JSON is stale* |

--- a/design/90-decisions.md
+++ b/design/90-decisions.md
@@ -9,6 +9,54 @@ Append-only. Newest at the top. The rejected alternatives are the point — with
 
 ---
 
+### 2026-09-02 — CP2 binds the invoked export, and the exporter's arguments are the error table's test seam
+Context: CP2 read "`content/` has exactly one production writer, and it writes nowhere else", and
+§ *Public surface* added that no parameter may make the exporter write elsewhere or write a subset.
+The tree has both parameters one level below the command line: `exportContent(catalogEntries,
+outputDir)`. `src/export-content.test.ts` drives it at a temporary directory to raise `WriteFailed`,
+and at substitute catalogs to raise `CampaignDidNotBuild` and `ValidationRejected` — so the contract
+forbade the seam its own error table needs, and the 2026-09-01 `WriteFailed` entry had already
+chosen a real filesystem rejection over a stub, which cannot be aimed at the published directory
+without publishing from it. Separately, the evidence check in `src/published-surface.test.ts`
+resolves the exporter's writes to the binding spelled `outputDir`, which inside `exportContent` is
+the argument shadowing the module constant — so it proved less than its name read. Found by
+/reconcile against the tree at `9cf09d0`.
+Chosen: Scope the contract to the invoked surface — CP2's second clause, and the `--out-dir`/`--only`
+sentence — and state the seam, why it exists, and the obligation it carries: a test that leaves
+`content/` differing from the committed export has failed whatever else it asserted, which is what
+every such test already ends on. The evidence check's title and comment now say what it resolves.
+This is the 2026-08-31 CP2/CP3 production-source scoping applied one level down, to the same rows,
+for the same reason.
+Rejected: Removing the parameters so CP2 is literally true of the function. It makes the row
+self-evident and costs the `WriteFailed` fixture — with no output directory the test must mock the
+filesystem or chmod the real `content/`, which is the stub the 2026-09-01 entry rejected by name.
+Also rejected: recording the breadth as known and retained, which leaves the contract asserting an
+invariant the tree does not hold — the shape 2026-08-29 (six SS invariants) refused.
+Reversibility: cheap — one table row and two paragraphs.
+
+---
+
+### 2026-09-02 — S23.4's `## Open` guard is bounded on the section separator
+Context: `## Open`'s S16.5 bullet says the item is kept there after filing "because S23.4's test
+(`src/campaigns/stable-life.test.ts`) asserts this exact entry stays in `## Open`". It did not. The
+test sliced from `## Open` to the next `## ` heading, and `## Open` is the last `## ` heading in the
+file, so the bound was -1 and the slice was 93,055 of the log's 93,211 bytes — the assertion searched
+the whole document. Verified by moving the bullet down among the dated entries: it still passed. The
+one transition the guard exists to catch — the item leaving the staging area `AGENTS.md` says a filed
+item leaves — was the transition it could not see, and had not seen since it landed at `79da1c8`.
+Found by /reconcile against the tree at `9cf09d0`.
+Chosen: Bound the slice on the `---` that closes `## Open`, which is the section's real end and does
+exist. Verified by reverting in both directions: the corrected guard passes as the log stands, and
+fails with the bullet relocated to either of two positions among the dated entries.
+Rejected: Weakening the bullet to claim only that the gap is named somewhere in the log. Honest, and
+it drops the retention rule the bullet exists for, leaving nothing checking the one fact
+`AGENTS.md`'s staging-area rule and issue #107 both turn on. Also rejected: deleting the assertion,
+which removes the only mechanical link between the campaign's CP10 omission and the open item that
+records it, leaving the pairing to the full-audit path.
+Reversibility: cheap — one expression.
+
+---
+
 ### 2026-09-01 — SS6 records the one overlap in its bucket counts rather than the code losing it
 Context: `Get-SpecSetBucketCounts` counts a reference as `Failed` when its status is
 `Unresolvable` and it carries a finding, and separately as `Unresolvable`. A cross-repository

--- a/design/state-index.md
+++ b/design/state-index.md
@@ -167,6 +167,8 @@ This document is a navigation view generated from `design/state/`. Edit the reco
 | decision/2026-09-01-ss6-records-the-one-overlap-in-its-bucket-counts-rather-than-the-code-losing-it | `unit/document/design-20-contract` |
 | decision/2026-09-01-the-content-path-s-gates-use-a-two-value-exit-and-only-never-0-is-contracted | `unit/document/design-20-contract` |
 | decision/2026-09-01-the-exporter-raises-writefailed-rather-than-letting-the-filesystem-s-error-escape | `unit/document/design-20-contract` |
+| decision/2026-09-02-cp2-binds-the-invoked-export-and-the-exporter-s-arguments-are-the-error-table-s-test-seam | — |
+| decision/2026-09-02-s23-4-s-open-guard-is-bounded-on-the-section-separator | — |
 <!-- decision-affects:end -->
 
 ## Question affects

--- a/design/state/decisions/2026-09-02-cp2-binds-the-invoked-export-and-the-exporter-s-arguments-are-the-error-table-s-test-seam.md
+++ b/design/state/decisions/2026-09-02-cp2-binds-the-invoked-export-and-the-exporter-s-arguments-are-the-error-table-s-test-seam.md
@@ -1,0 +1,17 @@
+# decision/2026-09-02-cp2-binds-the-invoked-export-and-the-exporter-s-arguments-are-the-error-table-s-test-seam
+Date: 2026-09-02
+Anchor: 2026-09-02 — CP2 binds the invoked export, and the exporter's arguments are the error table's test seam
+Status: accepted
+
+## Claim
+CP2 and the `--out-dir`/`--only` rule bind the invoked export — the script's command line and
+`main()`, which supply the module's `entries` and `outputDir` and are the only production caller.
+`exportContent`'s catalog and output-directory arguments are the seam the exporter's error table
+needs: `CampaignDidNotBuild` and `ValidationRejected` require a catalog that fails, and
+`WriteFailed` a filesystem that rejects a real write, which `90-decisions.md` (2026-09-01,
+`WriteFailed`) chose over a stub and which cannot be aimed at the published directory without
+publishing from it. The scope carries the obligation the 2026-08-31 production-source scope on CP2
+and CP3 carries: a test leaving `content/` different from the committed export has failed whatever
+else it asserted. `src/published-surface.test.ts` resolves writes to the binding spelled
+`outputDir`, which inside `exportContent` is the argument, and now says so rather than reading as a
+target resolution it does not perform.

--- a/design/state/decisions/2026-09-02-s23-4-s-open-guard-is-bounded-on-the-section-separator.md
+++ b/design/state/decisions/2026-09-02-s23-4-s-open-guard-is-bounded-on-the-section-separator.md
@@ -1,0 +1,13 @@
+# decision/2026-09-02-s23-4-s-open-guard-is-bounded-on-the-section-separator
+Date: 2026-09-02
+Anchor: 2026-09-02 — S23.4's `## Open` guard is bounded on the section separator
+Status: accepted
+
+## Claim
+S23.4's assertion that `design/90-decisions.md`'s S16.5 item is still in `## Open` slices that
+section to the `---` closing it, never to a following `## ` heading. `## Open` is the last such
+heading in the file, so that bound returned -1 and the assertion searched the whole log, passing
+with the item anywhere in it — the one transition it exists to catch is the item moving down among
+the dated entries, which is what `AGENTS.md`'s staging-area rule makes the checkable fact. A guard
+over a document section is bounded on a delimiter that exists, and is proven by moving the subject
+out and watching it fail.

--- a/src/campaigns/stable-life.test.ts
+++ b/src/campaigns/stable-life.test.ts
@@ -1009,10 +1009,16 @@ describe("Stable Life — goals and victory (S23)", () => {
       new URL("../../design/90-decisions.md", import.meta.url),
       "utf8",
     );
-    const openSection = decisionsLog.slice(
-      decisionsLog.indexOf("## Open"),
-      decisionsLog.indexOf("\n## ", decisionsLog.indexOf("## Open") + 1),
-    );
+    // Bounded on the `---` that closes `## Open`, because that is the section's real end and
+    // it exists. Slicing to the next `## ` heading did not: `## Open` is the last of those in
+    // the file, so the bound was -1 and the assertion searched the whole log — the item could
+    // move down among the dated entries and still pass, which is the one transition this is
+    // here to catch.
+    const openStart = decisionsLog.indexOf("## Open");
+    const openEnd = decisionsLog.indexOf("\n---", openStart);
+    expect(openStart).toBeGreaterThanOrEqual(0);
+    expect(openEnd).toBeGreaterThan(openStart);
+    const openSection = decisionsLog.slice(openStart, openEnd);
     expect(openSection).toContain("S16.5");
     expect(openSection).toContain("credential completion requirement");
   });

--- a/src/published-surface.test.ts
+++ b/src/published-surface.test.ts
@@ -229,11 +229,16 @@ describe("the single writer (CP2)", () => {
     expect(writers).toEqual(["scripts/export-content.ts"]);
   });
 
-  it("resolves every write and delete the exporter performs under content/", () => {
+  it("resolves every write and delete the exporter performs to outputDir, which main() supplies as content/", () => {
     const exporterPath = path.join(scriptsDir, "export-content.ts");
     const text = readFileSync(exporterPath, "utf8");
 
-    // outputDir must itself be declared as a path.join(..., "content").
+    // What this proves is narrower than "writes under content/", and the contract says so
+    // (`20-contract.md` § *Content path surfaces*): inside `exportContent`, `outputDir` is the
+    // argument, which a test may point elsewhere so `WriteFailed` can be raised by a real
+    // filesystem rejection. The two assertions together are the check CP2 gets — every write
+    // targets the binding spelled `outputDir`, and the module constant of that name is
+    // content/, which is what `main()` passes and nothing else in production does.
     const outputDirDeclaration = text.match(
       /const\s+outputDir\s*=\s*path\.join\([^)]*["']content["']\s*\)/,
     );


### PR DESCRIPTION
## Summary

A reconciliation pass against the tree at `9cf09d0`. Two divergences found, both decided, both applied.

**1. CP2's "writes nowhere else" contradicted the exporter's own signature.** CP2 read "`content/` has exactly one production writer, and it writes nowhere else", and § *Public surface* added that no parameter may make it write elsewhere or write a subset. `exportContent(catalogEntries, outputDir)` has both, one level below the command line, and the exporter's error table needs them — `CampaignDidNotBuild` and `ValidationRejected` want a catalog that fails, and `WriteFailed` wants a filesystem that rejects a real write, which the 2026-09-01 decision chose over a stub and which cannot be aimed at the published directory without publishing from it. Scoped the contract to the invoked surface (`main()` and the CLI), stated the seam and the obligation it carries, and corrected the evidence check's title and comment: it resolves writes to the binding spelled `outputDir`, which inside `exportContent` is the argument shadowing the module constant, so it proved less than its name read. Same move as the 2026-08-31 CP2/CP3 production-source scoping, one level down.

**2. S23.4's `## Open` guard guarded nothing.** The bullet in `## Open` says the S16.5 item is kept there after filing "because S23.4's test asserts this exact entry stays in `## Open`". It sliced from `## Open` to the next `## ` heading — and `## Open` is the last one in the file, so the bound was `-1` and the assertion searched all 93,055 of the log's 93,211 bytes. It has asserted nothing since it landed at `79da1c8`. Bounded on the `---` that closes the section.

Descriptive corrections alongside: `agent.md` pointed at `CLAUDE.md` for standing instructions and the graphify `--update` trap (both moved to `AGENTS.md` in the 2026-08-20 flip); its orientation said "game specs only", which the 2026-08-30 ownership decision contradicts; and `04-engine-specification.md`'s size was stated as ~104/~105 KB in `agent.md` and twice in `AGENTS.md` against an actual 114.5 KB, a figure `agent.md` uses for token budgeting.

Nothing in `design/30-slices.md` was touched, and no unlanded slice's criteria were edited.

## Test plan

Verified by reverting, as the repository requires:

- Finding 2's guard was confirmed vacuous by moving the S16.5 bullet down among the dated entries — the old test passed. The corrected guard passes as the log stands and **fails** with the bullet relocated to either of two positions among the entries.

Gates run, with what each reported:

| Gate | Result |
|---|---|
| `tools/Test-SpecSet.ps1` | exit 0 — Valid; 8 documents, 936 declarations, 2 mirror obligations checked, 8 references unresolvable |
| `tools/Test-Companion.ps1` | exit 0 — 23 cores, 0 companions |
| `tools/Test-DesignState.ps1` | **0 findings**; largest closure `unit/document/design-20-contract` at 14,417 of 16,384 bytes, unchanged. Exit 2 on `TrackerUnavailable` only |
| `npm run check` | typecheck clean, 71 tests passed / 4 files, export byte-identical, `content/` matches the sources |
| `Invoke-Pester -Path tools` | 338 passed / 15 failed |

**What did not run cleanly, and why it is not this change:** the 15 Pester failures are `Wait-PullRequestCheck` (12), `Invoke-DoneHousekeeping` worktree cases (3, counted within), `Update-DesignProjection` S7.10 and `Test-DesignState` S12.5/S18.6 — all of them needing `gh` or git-worktree support absent from this environment. The identical 15 fail on a pristine checkout of `9cf09d0`, confirmed by stashing this branch's changes and re-running. `Test-DesignState.ps1`'s exit 2 has the same cause and is the behaviour `20-contract.md` § *Could not evaluate* specifies.

Two decision-log entries were appended with matching `design/state/decisions/` records, and the projection regenerated before the checker ran, per `AGENTS.md` § *Writing a design-state record*. Neither id was added to a unit's `Live`: both write their terms into their site in this same change, which is step 4's absorption case — recorded in the site alone, since `StatedIn` is not in the pinned kit's record grammar (issue #113, blocked upstream).

No AI-attribution footer, per `AGENTS.md` § *House conventions*.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaF55pEwwev3ZAGGpgdZXh)_